### PR TITLE
Parse out sql from code block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "vanna"
-version = "0.0.33"
+version = "0.0.34"
 authors = [
   { name="Zain Hoda", email="zain@vanna.ai" },
 ]


### PR DESCRIPTION
GPT-4 Turbo (i.e. `gpt-4-1106-preview`) tends to return the SQL inside a markdown code block. This adds a method to the base class to parse out the SQL from the code block. 