### PR TITLE
Minor refactoring in ChromaDB class; renamed method; added description to method

### DIFF
--- a/src/vanna/chromadb/chromadb_vector.py
+++ b/src/vanna/chromadb/chromadb_vector.py
@@ -154,7 +154,7 @@ class ChromaDB_VectorStore(VannaBase):
             return True
         else:
             return False
-    def reomove_collection(self, collection_name: str) -> bool:
+    def remove_collection(self, collection_name: str) -> bool:
         """
         This function can reset the collection to empty state. 
 

--- a/src/vanna/chromadb/chromadb_vector.py
+++ b/src/vanna/chromadb/chromadb_vector.py
@@ -154,6 +154,7 @@ class ChromaDB_VectorStore(VannaBase):
             return True
         else:
             return False
+    
     def remove_collection(self, collection_name: str) -> bool:
         """
         This function can reset the collection to empty state. 
@@ -184,9 +185,18 @@ class ChromaDB_VectorStore(VannaBase):
             return True
         else:
             return False
-    # Static method to extract the documents from the results of a query
+    
     @staticmethod
     def _extract_documents(query_results) -> list:
+        """
+        Static method to extract the documents from the results of a query.
+
+        Args:
+            query_results (pd.DataFrame): The dataframe to use.
+        
+        Returns:
+            List[str] or None: The extracted documents, or an empty list or single document if an error occurred.
+        """
         if query_results is None:
             return []
 


### PR DESCRIPTION
I verified that the method `reomove_collection` with typo was not used elsewhere in Vanna.

Hence, this renaming should not affect the rest of the framework (see [here](https://github.com/search?q=repo%3Avanna-ai%2Fvanna%20reomove_collection&type=code)).