### PR TITLE
fix(flask): no followup questions error

### DIFF
--- a/src/vanna/flask/__init__.py
+++ b/src/vanna/flask/__init__.py
@@ -319,6 +319,7 @@ class VannaFlaskApp:
                     }
                 )
             else:
+                cache.set(id=id, field="followup_questions", value=[])
                 return jsonify(
                     {
                         "type": "question_list",


### PR DESCRIPTION
# Issue
When using the flask app using the new option `allow_llm_to_see_data=False`, followup questions are not generated, which becomes a problem when reloading the question as followup questions are required in cache for the function `load_question`, which throws an error:  
![image](https://github.com/vanna-ai/vanna/assets/76754000/06185205-c0ca-4f5a-8a40-cc484f032429)  

# Fix  
Cache an empty array for followup questions with `allow_llm_to_see_data=False` option