### PR TITLE
Added smart import shortcuts for some submodules

### DIFF
--- a/src/vanna/ZhipuAI/ZhipuAI_Chat.py
+++ b/src/vanna/ZhipuAI/ZhipuAI_Chat.py
@@ -1,11 +1,11 @@
 import re
 from typing import List
+
 import pandas as pd
 from zhipuai import ZhipuAI
+
 from ..base import VannaBase
-import re
-from typing import List
-import pandas as pd
+
 
 class ZhipuAI_Chat(VannaBase):
     def __init__(self, config=None):

--- a/src/vanna/ZhipuAI/__init__.py
+++ b/src/vanna/ZhipuAI/__init__.py
@@ -1,0 +1,2 @@
+from .ZhipuAI_Chat import ZhipuAI_Chat
+from .ZhipuAI_embeddings import ZhipuAI_Embeddings, ZhipuAIEmbeddingFunction

--- a/src/vanna/anthropic/__init__.py
+++ b/src/vanna/anthropic/__init__.py
@@ -1,0 +1,1 @@
+from .anthropic_chat import Anthropic_Chat

--- a/src/vanna/chromadb/__init__.py
+++ b/src/vanna/chromadb/__init__.py
@@ -1,0 +1,1 @@
+from .chromadb_vector import ChromaDB_VectorStore

--- a/src/vanna/marqo/__init__.py
+++ b/src/vanna/marqo/__init__.py
@@ -1,0 +1,1 @@
+from .marqo import Marqo_VectorStore

--- a/src/vanna/marqo/marqo.py
+++ b/src/vanna/marqo/marqo.py
@@ -1,6 +1,4 @@
-import json
 import uuid
-from abc import abstractmethod
 
 import marqo
 import pandas as pd

--- a/src/vanna/mistral/__init__.py
+++ b/src/vanna/mistral/__init__.py
@@ -1,0 +1,1 @@
+from .mistral import Mistral

--- a/src/vanna/ollama/__init__.py
+++ b/src/vanna/ollama/__init__.py
@@ -1,0 +1,1 @@
+from .ollama import Ollama

--- a/src/vanna/ollama/ollama.py
+++ b/src/vanna/ollama/ollama.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import requests

--- a/src/vanna/openai/__init__.py
+++ b/src/vanna/openai/__init__.py
@@ -1,0 +1,2 @@
+from .openai_chat import OpenAI_Chat
+from .openai_embeddings import OpenAI_Embeddings

--- a/src/vanna/vannadb/__init__.py
+++ b/src/vanna/vannadb/__init__.py
@@ -1,0 +1,1 @@
+from .vannadb_vector import VannaDB_VectorStore


### PR DESCRIPTION
As observed in https://github.com/vanna-ai/vanna/pull/259#issuecomment-2027242687, some classes like `Ollama` can not be accessed as wanted.

Currently, to access it, the user would need to write:
```
from vanna.ollama.ollama import Ollama
```

But the ideal behaviour is:
```
from vanna.ollama import Ollama
```

**This PR adds support to allow both (with and without smart import shortcut).**

I added the same to some other relevant submodules such as `Mistral`, `Anthropic`, `OpenAI`, `ZhipuAI`.

---
EDIT: I also now added the same to the vector DB classes, such as `MarqoDB`, `VannaDB`, and `ChromaDB`.