### PR TITLE
Allow to set `model` for separate `submit_prompt` calls to OpenAI

### DIFF
--- a/src/vanna/openai/openai_chat.py
+++ b/src/vanna/openai/openai_chat.py
@@ -41,7 +41,7 @@ class OpenAI_Chat(VannaBase):
         if config is None and client is None:
             self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
             return
-      
+
         if "api_key" in config:
             self.client = OpenAI(api_key=config["api_key"])
 
@@ -67,7 +67,18 @@ class OpenAI_Chat(VannaBase):
         for message in prompt:
             num_tokens += len(message["content"]) / 4
 
-        if self.config is not None and "engine" in self.config:
+        if kwargs.get("model", None) is not None:
+            print(
+                f"Using model {self.config['model']} for {num_tokens} tokens (approx)"
+            )
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=prompt,
+                max_tokens=self.max_tokens,
+                stop=None,
+                temperature=self.temperature,
+            )
+        elif self.config is not None and "engine" in self.config:
             print(
                 f"Using engine {self.config['engine']} for {num_tokens} tokens (approx)"
             )

--- a/src/vanna/openai/openai_chat.py
+++ b/src/vanna/openai/openai_chat.py
@@ -72,7 +72,18 @@ class OpenAI_Chat(VannaBase):
                 f"Using model {self.config['model']} for {num_tokens} tokens (approx)"
             )
             response = self.client.chat.completions.create(
-                model=model,
+                model=kwargs.get("model", None),
+                messages=prompt,
+                max_tokens=self.max_tokens,
+                stop=None,
+                temperature=self.temperature,
+            )
+        elif kwargs.get("engine", None) is not None:
+            print(
+                f"Using model {self.config['model']} for {num_tokens} tokens (approx)"
+            )
+            response = self.client.chat.completions.create(
+                engine=kwargs.get("engine", None),
                 messages=prompt,
                 max_tokens=self.max_tokens,
                 stop=None,

--- a/src/vanna/openai/openai_chat.py
+++ b/src/vanna/openai/openai_chat.py
@@ -68,22 +68,24 @@ class OpenAI_Chat(VannaBase):
             num_tokens += len(message["content"]) / 4
 
         if kwargs.get("model", None) is not None:
+            model = kwargs.get("model", None)
             print(
-                f"Using model {self.config['model']} for {num_tokens} tokens (approx)"
+                f"Using model {model} for {num_tokens} tokens (approx)"
             )
             response = self.client.chat.completions.create(
-                model=kwargs.get("model", None),
+                model=model,
                 messages=prompt,
                 max_tokens=self.max_tokens,
                 stop=None,
                 temperature=self.temperature,
             )
         elif kwargs.get("engine", None) is not None:
+            engine = kwargs.get("engine", None)
             print(
-                f"Using model {self.config['model']} for {num_tokens} tokens (approx)"
+                f"Using model {engine} for {num_tokens} tokens (approx)"
             )
             response = self.client.chat.completions.create(
-                engine=kwargs.get("engine", None),
+                engine=engine,
                 messages=prompt,
                 max_tokens=self.max_tokens,
                 stop=None,


### PR DESCRIPTION
Fixes #332.

## Changes
- [x] Add support to set both `model` and `engine` for `submit_prompt` events.
- [x] Allow changing model for different calls without affecting the base vanna instance.

Seems to work fine. I did a small test below to verify that setting the `model` with this new API works, but I was unable to run tests. Not sure why. Are you able to test and verify that it runs fine, @zainhoda?

I set the model explicitly when running `generate_sql` like so:
```
sql = vn_openai.generate_sql("What are the top 4 customers by sales?", model="gpt-4")
```

To test that it works I just added two prints into the code itself (not included in PR, just for testing):
<img width="599" alt="Screenshot 2024-04-02 at 18 08 21" src="https://github.com/vanna-ai/vanna/assets/29090665/cc2ebe14-457f-4a21-b39a-6afb79b5e8e6">

Console showing that the model is set and passed appropriately to the completion call:
<img width="1198" alt="Screenshot 2024-04-02 at 18 07 43" src="https://github.com/vanna-ai/vanna/assets/29090665/613763b0-5b50-46e9-b113-b97d9be84845">

