### PR TITLE
[Scalabrese] Added client_session_keep_alive = True to Snowflake

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -62,6 +62,7 @@ import plotly
 import plotly.express as px
 import plotly.graph_objects as go
 import requests
+from snowflake.connector.connection import SnowflakeConnection
 
 from ..exceptions import DependencyError, ImproperlyConfigured, ValidationError
 from ..types import TrainingPlan, TrainingPlanItem
@@ -649,11 +650,12 @@ class VannaBase(ABC):
             else:
                 raise ImproperlyConfigured("Please set your Snowflake database.")
 
-        conn = snowflake.connector.connect(
+        conn:SnowflakeConnection = snowflake.connector.connect(
             user=username,
             password=password,
             account=account,
             database=database,
+            client_session_keep_alive=True
         )
 
         def run_sql_snowflake(sql: str) -> pd.DataFrame:

--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -62,7 +62,6 @@ import plotly
 import plotly.express as px
 import plotly.graph_objects as go
 import requests
-from snowflake.connector.connection import SnowflakeConnection
 
 from ..exceptions import DependencyError, ImproperlyConfigured, ValidationError
 from ..types import TrainingPlan, TrainingPlanItem
@@ -650,7 +649,7 @@ class VannaBase(ABC):
             else:
                 raise ImproperlyConfigured("Please set your Snowflake database.")
 
-        conn:SnowflakeConnection = snowflake.connector.connect(
+        conn = snowflake.connector.connect(
             user=username,
             password=password,
             account=account,


### PR DESCRIPTION
If Vanna is running on a microservice (for example FastAPI) it can happen that the service is not running for more than 4 hours so Snowflake Token expires.

This happens when the app runs "connect_to_snowflake" at the application startup.

I would suggest to make the connection always active until the service is running otherwise the service will fail.