### PR TITLE
fix: exceptions not caught with `except Exception as e:`

### DIFF
--- a/src/vanna/exceptions/__init__.py
+++ b/src/vanna/exceptions/__init__.py
@@ -1,46 +1,46 @@
-class ImproperlyConfigured(BaseException):
+class ImproperlyConfigured(Exception):
     """Raise for incorrect configuration."""
 
     pass
 
 
-class DependencyError(BaseException):
+class DependencyError(Exception):
     """Raise for missing dependencies."""
 
     pass
 
 
-class ConnectionError(BaseException):
+class ConnectionError(Exception):
     """Raise for connection"""
 
     pass
 
 
-class OTPCodeError(BaseException):
+class OTPCodeError(Exception):
     """Raise for invalid otp or not able to send it"""
 
     pass
 
 
-class SQLRemoveError(BaseException):
+class SQLRemoveError(Exception):
     """Raise when not able to remove SQL"""
 
     pass
 
 
-class ExecutionError(BaseException):
+class ExecutionError(Exception):
     """Raise when not able to execute Code"""
 
     pass
 
 
-class ValidationError(BaseException):
+class ValidationError(Exception):
     """Raise for validations"""
 
     pass
 
 
-class APIError(BaseException):
+class APIError(Exception):
     """Raise for API errors"""
 
     pass


### PR DESCRIPTION
# Description  
The exceptions defined in vanna.exceptions can not be catched with a `try: ... except Exception as e:`.  

# Reproduction  
```python
from vanna.exceptions import ValidationError

try:
    raise ValidationError()
except Exception as e:
    print("Caught with Exception")
# this raises an error

try:
    raise ValidationError()
except BaseException as e:
    print("Caught with BaseException")
# This does not
```

# Explanation  
Vanna exceptions are all derived from the class `BaseException` instead of the class `Exception`.
```python
class ValidationError(BaseException):
class Exception(BaseException):
class BaseException(object):
```
Therefore, they cannot be catched with `try: ... except Exception as e:` ([BaseException Documentation](https://docs.python.org/3.12/library/exceptions.html#BaseException)).

# Solution
Define Exception as the parent class of all Vanna Exceptions instead of BaseException. 

# Alternative solution
It would be cleaner to have 
```python
class VannaError(Exception):
    pass
class ValidationError(VannaError):
    pass
```  
and to only use a `try: ... except VannaError as e:` block when necessary, but this is not the focus of this PR.