### PR TITLE
fix(bigquery-connection): Fix chain authen logic when we try to create bigquery client

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -1146,19 +1146,14 @@ class VannaBase(ABC):
 
         conn = None
 
-        try:
-            conn = bigquery.Client(project=project_id)
-        except:
-            print("Could not found any google cloud implicit credentials")
-
-        if cred_file_path:
+        if not cred_file_path:
+            try:
+                conn = bigquery.Client(project=project_id)
+            except:
+                print("Could not found any google cloud implicit credentials")
+        else:
             # Validate file path and pemissions
             validate_config_path(cred_file_path)
-        else:
-            if not conn:
-                raise ValidationError(
-                    "Pleae provide a service account credentials json file"
-                )
 
         if not conn:
             with open(cred_file_path, "r") as f:


### PR DESCRIPTION
**Issue - context:**
When we deploy vanna app on a instance (Pod of K8S -  GKE) which already have a default credential of a service account. However, we would like to use the other credential as input file name for the app. We cannot do it with the current logic.
[The lib always use default credential first. ](https://github.com/vanna-ai/vanna/blob/main/src/vanna/base/base.py#L1149)

**What is the change:** 
Changed the chain authentication logic.