### PR TITLE
Fix string concatenation in initial_prompt

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -555,7 +555,7 @@ class VannaBase(ABC):
         """
 
         if initial_prompt is None:
-            initial_prompt = f"You are a {self.dialect} expert. "
+            initial_prompt = f"You are a {self.dialect} expert. " + \
             "Please help to generate a SQL query to answer the question. Your response should ONLY be based on the given context and follow the response guidelines and format instructions. "
 
         initial_prompt = self.add_ddl_to_prompt(


### PR DESCRIPTION
**old version:**

```python
dialect = "SQL"
initial_prompt = f"You are a {dialect} expert. "
"Please help to generate a SQL query to answer the question. Your response should ONLY be based on the given context and follow the response guidelines and format instructions. "
print(initial_prompt)
```

terminal ouput:

```log
You are a SQL expert.
```

**new version:**

```python
dialect = "SQL"
initial_prompt = f"You are a {dialect} expert. " + \
"Please help to generate a SQL query to answer the question. Your response should ONLY be based on the given context and follow the response guidelines and format instructions. "
print(initial_prompt)
```

terminal ouput:

```log
You are a SQL expert. Please help to generate a SQL query to answer the question. Your response should ONLY be based on the given context and follow the response guidelines and format instructions. 
```