### PR TITLE
Two optimizations: log and allow_llm_to_see_data

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -81,7 +81,7 @@ class VannaBase(ABC):
         self.language = self.config.get("language", None)
 
     def log(self, message: str, title: str = "Info"):
-        print(message)
+        print(f"{title}: {message}")
 
     def _response_language(self) -> str:
         if self.language is None:

--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -1597,6 +1597,7 @@ class VannaBase(ABC):
         print_results: bool = True,
         auto_train: bool = True,
         visualize: bool = True,  # if False, will not generate plotly code
+        allow_llm_to_see_data: bool = False,
     ) -> Union[
         Tuple[
             Union[str, None],

--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -1628,7 +1628,7 @@ class VannaBase(ABC):
             question = input("Enter a question: ")
 
         try:
-            sql = self.generate_sql(question=question)
+            sql = self.generate_sql(question=question, allow_llm_to_see_data=allow_llm_to_see_data)
         except Exception as e:
             print(e)
             return None, None, None


### PR DESCRIPTION
**Optimize the usage of `title` in the `log` function within `base.py`:**

I noticed that the `title` variable in the log function is not actually used. For example:

```python
    def log(self, message: str, title: str = "Info"):
        print(message)
```

```python
self.log(title="LLM Response", message=llm_response)
```

**Add the parameter allow_llm_to_see_data=False to the ask function:**

When I ran my code, the terminal displayed the following message:

```log
The LLM is not allowed to see the data in your database. Your question requires database introspection to generate the necessary SQL. Please set allow_llm_to_see_data=True to enable this.
```

I checked the parameters of the `ask` function to add this parameter but found that the `ask` function does not have this parameter. 

Instead, this parameter is used in the `ask` function's `sql = self.generate_sql(question=question)` section. Therefore, I made this modification.