### PR TITLE
fix(flask): missing fig_json error

### DIFF
--- a/src/vanna/flask/__init__.py
+++ b/src/vanna/flask/__init__.py
@@ -578,8 +578,8 @@ class VannaFlaskApp:
         @self.flask_app.route("/api/v0/load_question", methods=["GET"])
         @self.requires_auth
         @self.requires_cache(
-            ["question", "sql", "df", "fig_json"],
-            optional_fields=["summary"]
+            ["question", "sql", "df"],
+            optional_fields=["summary", "fig_json"]
         )
         def load_question(user: any, id: str, question, sql, df, fig_json, summary):
             try:


### PR DESCRIPTION
related to #428 
# Problem
When no graph is generated, retrieving a converstation through the history fails as the cache is expecting a `fig_json` field.  
The following error is displayed: 
![image](https://github.com/vanna-ai/vanna/assets/76754000/307c2eaa-18b6-4f3b-bddd-2823d62f0d82)
 
# Solution  
set fig_json as an optional field instead of a required one for the function `VannaFlaskApp.load_question`. The conversation is then displayed, followed by an empty graph:  
![image](https://github.com/vanna-ai/vanna/assets/76754000/b76c0e07-7d4a-4c20-b738-580c0c09fdb5)  

# Improvements
It would be good to take into account the possibility of `fig` being null in the JS displaying the graph so that it shows nothing instead of an epty graph, but as it is in the assets I can't modify it.