### PR TITLE
Fix qdrant `remove_training_data` api

### DIFF
--- a/src/vanna/qdrant/qdrant.py
+++ b/src/vanna/qdrant/qdrant.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 
 import pandas as pd
 from qdrant_client import QdrantClient, grpc, models
+from qdrant_client.http.models.models import UpdateStatus
 
 from ..base import VannaBase
 from ..utils import deterministic_uuid
@@ -210,7 +211,8 @@ class Qdrant_VectorStore(VannaBase):
     def remove_training_data(self, id: str, **kwargs) -> bool:
         try:
             id, collection_name = self._parse_point_id(id)
-            self._client.delete(collection_name, points_selector=[id])
+            res = self._client.delete(collection_name, points_selector=[id])
+            res == UpdateStatus.COMPLETED
         except ValueError:
             return False
 


### PR DESCRIPTION
Return `True` if successful deletion of training data.

Previous version returned `None`.