### PR TITLE
fix: draw figure bug

### DIFF
--- a/src/vanna/flask/__init__.py
+++ b/src/vanna/flask/__init__.py
@@ -494,15 +494,12 @@ class VannaFlaskApp:
         def generate_plotly_figure(user: any, id: str, df, question, sql):
             chart_instructions = flask.request.args.get('chart_instructions')
 
-            if chart_instructions is not None:
-                question = f"{question}. When generating the chart, use these special instructions: {chart_instructions}"
-
             try:
                 # If chart_instructions is not set then attempt to retrieve the code from the cache
                 if chart_instructions is None or len(chart_instructions) == 0:
                     code = self.cache.get(id=id, field="plotly_code")
-
-                if code is None:
+                else:
+                    question = f"{question}. When generating the chart, use these special instructions: {chart_instructions}"
                     code = vn.generate_plotly_code(
                         question=question,
                         sql=sql,


### PR DESCRIPTION
An error occurs when redraw figure is executed：
`UnboundLocalError: local variable 'code' referenced before assignment`
![微信图片_20240614112155](https://github.com/vanna-ai/vanna/assets/42793700/3e93fd24-88c6-4b92-a356-5264d08cbbec)

The bug is fixed by this commit.
![微信图片_20240614112202](https://github.com/vanna-ai/vanna/assets/42793700/143fd1c5-9205-453a-a75d-c008d8dfcea9)
