### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/src/vanna/__init__.py
+++ b/src/vanna/__init__.py
@@ -62,8 +62,8 @@ def __unauthenticated_rpc_call(method, params):
     data = {"method": method, "params": [__dataclass_to_dict(obj) for obj in params]}
 
     response = requests.post(
-        _unauthenticated_endpoint, headers=headers, data=json.dumps(data)
-    )
+        _unauthenticated_endpoint, headers=headers, data=json.dumps(data), 
+    timeout=60)
     return response.json()
 
 

--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -808,7 +808,7 @@ class VannaBase(ABC):
 
         # Download the database if it doesn't exist
         if not os.path.exists(url):
-            response = requests.get(url)
+            response = requests.get(url, timeout=60)
             response.raise_for_status()  # Check that the request was successful
             with open(path, "wb") as f:
                 f.write(response.content)
@@ -1297,7 +1297,7 @@ class VannaBase(ABC):
                 path = os.path.basename(urlparse(url).path)
                 # Download the database if it doesn't exist
                 if not os.path.exists(path):
-                    response = requests.get(url)
+                    response = requests.get(url, timeout=60)
                     response.raise_for_status()  # Check that the request was successful
                     with open(path, "wb") as f:
                         f.write(response.content)

--- a/src/vanna/flask/__init__.py
+++ b/src/vanna/flask/__init__.py
@@ -736,7 +736,7 @@ class VannaFlaskApp:
         @self.flask_app.route("/vanna.svg")
         def proxy_vanna_svg():
             remote_url = "https://vanna.ai/img/vanna.svg"
-            response = requests.get(remote_url, stream=True)
+            response = requests.get(remote_url, stream=True, timeout=60)
 
             # Check if the request to the remote URL was successful
             if response.status_code == 200:

--- a/src/vanna/vannadb/vannadb_vector.py
+++ b/src/vanna/vannadb/vannadb_vector.py
@@ -60,7 +60,7 @@ class VannaDB_VectorStore(VannaBase, VannaAdvanced):
             "params": [self._dataclass_to_dict(obj) for obj in params],
         }
 
-        response = requests.post(self._endpoint, headers=headers, data=json.dumps(data))
+        response = requests.post(self._endpoint, headers=headers, data=json.dumps(data), timeout=60)
         return response.json()
 
     def _dataclass_to_dict(self, obj):
@@ -85,7 +85,7 @@ class VannaDB_VectorStore(VannaBase, VannaAdvanced):
             }
         """
 
-        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': query})
+        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': query}, timeout=60)
         response_json = response.json()
         if response.status_code == 200 and 'data' in response_json and 'get_all_sql_functions' in response_json['data']:
             self.log(response_json['data']['get_all_sql_functions'])
@@ -123,7 +123,7 @@ class VannaDB_VectorStore(VannaBase, VannaAdvanced):
         """
         static_function_arguments = [{"name": key, "value": str(value)} for key, value in additional_data.items()]
         variables = {"question": question, "staticFunctionArguments": static_function_arguments}
-        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': query, 'variables': variables})
+        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': query, 'variables': variables}, timeout=60)
         response_json = response.json()
         if response.status_code == 200 and 'data' in response_json and 'get_and_instantiate_function' in response_json['data']:
             self.log(response_json['data']['get_and_instantiate_function'])
@@ -153,7 +153,7 @@ class VannaDB_VectorStore(VannaBase, VannaAdvanced):
         }
         """
         variables = {"question": question, "sql": sql, "plotly_code": plotly_code}
-        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': query, 'variables': variables})
+        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': query, 'variables': variables}, timeout=60)
         response_json = response.json()
         if response.status_code == 200 and 'data' in response_json and response_json['data'] is not None and 'generate_and_create_sql_function' in response_json['data']:
             resp = response_json['data']['generate_and_create_sql_function']
@@ -216,7 +216,7 @@ class VannaDB_VectorStore(VannaBase, VannaAdvanced):
 
         print("variables", variables)
 
-        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': mutation, 'variables': variables})
+        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': mutation, 'variables': variables}, timeout=60)
         response_json = response.json()
         if response.status_code == 200 and 'data' in response_json and response_json['data'] is not None and 'update_sql_function' in response_json['data']:
             return response_json['data']['update_sql_function']
@@ -230,7 +230,7 @@ class VannaDB_VectorStore(VannaBase, VannaAdvanced):
         }
         """
         variables = {"function_name": function_name}
-        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': mutation, 'variables': variables})
+        response = requests.post(self._graphql_endpoint, headers=self._graphql_headers, json={'query': mutation, 'variables': variables}, timeout=60)
         response_json = response.json()
         if response.status_code == 200 and 'data' in response_json and response_json['data'] is not None and 'delete_sql_function' in response_json['data']:
             return response_json['data']['delete_sql_function']

--- a/src/vanna/vllm/vllm.py
+++ b/src/vanna/vllm/vllm.py
@@ -78,11 +78,11 @@ class Vllm(VannaBase):
             'Authorization': f'Bearer {self.auth_key}' 
             }
 
-            response = requests.post(url, headers=headers,json=data)
+            response = requests.post(url, headers=headers,json=data, timeout=60)
 
 
         else:
-            response = requests.post(url, json=data)
+            response = requests.post(url, json=data, timeout=60)
 
         response_dict = response.json()
 


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fvanna%7C54e4aa054157284c93ce1e007ea5a95b1f7c1d8e)


<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->