### PR TITLE
fix: model name for gemini chat is hardcoded when no api-key is used

### DIFF
--- a/src/vanna/google/gemini_chat.py
+++ b/src/vanna/google/gemini_chat.py
@@ -7,7 +7,7 @@ class GoogleGeminiChat(VannaBase):
         VannaBase.__init__(self, config=config)
 
         # default temperature - can be overrided using config
-        self.temperature = 0.7      
+        self.temperature = 0.7
 
         if "temperature" in config:
             self.temperature = config["temperature"]
@@ -31,7 +31,7 @@ class GoogleGeminiChat(VannaBase):
         else:
             # Authenticate using VertexAI
             from vertexai.preview.generative_models import GenerativeModel
-            self.chat_model = GenerativeModel("gemini-pro")
+            self.chat_model = GenerativeModel(model_name)
 
     def system_message(self, message: str) -> any:
         return message


### PR DESCRIPTION
The current `GoogleGeminiChat` does not respect `model_name` when authenticating without api-key.
This is a one-liner fix.