### PR TITLE
Add temperature support to vLLM

### DIFF
--- a/src/vanna/vllm/vllm.py
+++ b/src/vanna/vllm/vllm.py
@@ -22,6 +22,12 @@ class Vllm(VannaBase):
         else:
             self.auth_key = None
 
+        if "temperature" in config:
+            self.temperature = config["temperature"]
+        else:
+            # default temperature - can be overrided using config
+            self.temperature = 0.7
+
     def system_message(self, message: str) -> any:
         return {"role": "system", "content": message}
 
@@ -68,6 +74,7 @@ class Vllm(VannaBase):
         url = f"{self.host}/v1/chat/completions"
         data = {
             "model": self.model,
+            "temperature": self.temperature,
             "stream": False,
             "messages": prompt,
         }


### PR DESCRIPTION
Added temperature support for hosted LLM using vLLM

Changes made:
* Introduced default temperature of 0.7 in __init__ method
* Updated JSON payload in submit_prompt method to include temperature


This change allows users to control the randomness of the model's output.  If not specified, it defaults to 0.7, providing a balance between creativity and coherence in the generated text.