### PR TITLE
Prompt Content not print unicode char

### DIFF
--- a/src/vanna/ollama/ollama.py
+++ b/src/vanna/ollama/ollama.py
@@ -91,7 +91,7 @@ class Ollama(VannaBase):
       f"model={self.model},\n"
       f"options={self.ollama_options},\n"
       f"keep_alive={self.keep_alive}")
-    self.log(f"Prompt Content:\n{json.dumps(prompt)}")
+    self.log(f"Prompt Content:\n{json.dumps(prompt, ensure_ascii=False)}")
     response_dict = self.ollama_client.chat(model=self.model,
                                             messages=prompt,
                                             stream=False,

--- a/src/vanna/remote.py
+++ b/src/vanna/remote.py
@@ -62,7 +62,7 @@ class VannaDefault(VannaDB_VectorStore):
 
     def submit_prompt(self, prompt, **kwargs) -> str:
         # JSON-ify the prompt
-        json_prompt = json.dumps(prompt)
+        json_prompt = json.dumps(prompt, ensure_ascii=False)
 
         params = [StringData(data=json_prompt)]
 


### PR DESCRIPTION
<img width="938" alt="image" src="https://github.com/user-attachments/assets/70183479-fec7-43be-b038-e86e62d600de">

json.dumps without ensure_ascii=False will print unicode char which is not convinient to read.