### PR TITLE
Add Autocommit Option to connect_to_mysql for Accurate Database Query Results

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -992,6 +992,7 @@ class VannaBase(ABC):
         user: str = None,
         password: str = None,
         port: int = None,
+        autocommit: bool = False,
         **kwargs
     ):
 
@@ -1043,6 +1044,7 @@ class VannaBase(ABC):
                 database=dbname,
                 port=port,
                 cursorclass=pymysql.cursors.DictCursor,
+                autocommit=autocommit,
                 **kwargs
             )
         except pymysql.Error as e:
@@ -1079,7 +1081,7 @@ class VannaBase(ABC):
         dbname: str = None,
         user: str = None,
         password: str = None,
-        port: int = None,
+        port: int = None,        
         **kwargs
     ):
 


### PR DESCRIPTION
This pull request adds an `autocommit` parameter to the `connect_to_mysql` method, enabling users to toggle autocommit mode on MySQL connections. By setting `autocommit=True`, users can ensure the latest data changes in the database are reflected in their queries, solving an issue where cached results would appear even after data modifications.

#### Background
Some users have reported that query results returned by the Vanna application do not update immediately after data changes in the database. This is due to the default transaction behavior of MySQL when `autocommit` is set to `False`, which can lead to reading shadowed copies of data. The addition of the `autocommit` parameter provides a way to address this issue, allowing more accurate and timely data retrieval.

#### Changes Made
- Added an `autocommit` parameter to the `connect_to_mysql` function (default: `False` for backward compatibility).
- Updated the `pymysql.connect` function call to include `autocommit=autocommit` in the connection parameters.

#### Usage
Users can enable `autocommit` mode by calling:
```python
connect_to_mysql(host='localhost', user='user', password='password', dbname='db', autocommit=True)
```

Enabling `autocommit` ensures that the database fetches the most up-to-date records, improving the reliability and consistency of query results within the Vanna application.