### PR TITLE
Update pinecone_vector.py

### DIFF
--- a/src/vanna/pinecone/pinecone_vector.py
+++ b/src/vanna/pinecone/pinecone_vector.py
@@ -111,7 +111,7 @@ class PineconeDB_VectorStore(VannaBase):
 
     def _check_if_embedding_exists(self, id: str, namespace: str) -> bool:
         fetch_response = self.Index.fetch(ids=[id], namespace=namespace)
-        if fetch_response["vectors"] == {}:
+        if fetch_response.vectors == {}:
             return False
         return True
 


### PR DESCRIPTION
In newer versions of the Pinecone client, the fetch() method returns a FetchResponse object, not a simple dictionary. And this object is not subscriptable.