### PR TITLE
Fix: Prevent SQL Trimming on Semicolons Within String Literals

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -206,9 +206,21 @@ class VannaBase(ABC):
 
         # Match SELECT ... ;
         sqls = re.findall(
-            r"\bSELECT\b .*?(?:'(?:[^']|''|\\')*'|\"(?:[^\"]|\\\")*\")*?[^;]*;",
+            r"""
+            \bSELECT\b                                # SELECT keyword
+            (?:                                       # Non-capturing group for the whole query
+                [^'"`;]*                              # Non-quote/semi-colon characters
+                (?:                                   # Alternation for quoted strings
+                    '(?:[^'\\]|\\.|'')*'              # single-quoted string
+                    |"(?:[^"\\]|\\.)*"                # double-quoted string
+                    |`(?:[^`\\]|\\.)*`                # backtick-quoted string (optional)
+                )
+            )*?                                       # Repeat lazily
+            [^'"`]*?                                  # Any remaining non-quote/semi-colon chars
+            ;                                         # Final semicolon outside of quotes
+            """,
             llm_response,
-            re.DOTALL | re.IGNORECASE,
+            re.DOTALL | re.IGNORECASE | re.VERBOSE
         )
         if sqls:
             sql = sqls[-1]


### PR DESCRIPTION
Bug: Vanna is incorrectly trimming SQL at semicolons, even when they appear inside string literals (e.g., 'dtmi:com:test:Fixture:Fixture1;1').

Impact: This breaks valid queries and causes execution to fail.

Fix Suggestion: Update the parser to ignore semicolons inside quotes. 

Note: Consider using a proper SQL tokenizer or sqlparse to handle this cleanly.

issue #831 



code used for testing:

`%pip install -q "git+https://github.com/kdshreyas/vanna@fix/issue-831-fix_extract_sql#egg=vanna[chromadb,snowflake,openai]"`

```

from vanna.remote import VannaDefault
vn = VannaDefault(model='chinook', api_key=vanna.get_api_key('hello@gmail.com')) #replace with your email id
vn.connect_to_sqlite('https://vanna.ai/Chinook.sqlite')
vn.ask("What are the top 10 albums by sales?")
```

```

vn.train(ddl='''
    select * from fixture_info where "objectId" = 'dtmi:com:test:Fixture:Fixture1;1'
    ''')
```

`vn.generate_sql("get fixture_info for 'dtmi:com:test:Fixture:Fixture1;1'")`
