### PR TITLE
fix password check for pg connect

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -939,7 +939,7 @@ class VannaBase(ABC):
             password = os.getenv("PASSWORD")
 
         if password is None:
-          raise ImproperlyConfigured("Please set your postgres password")
+            raise ImproperlyConfigured("Please set your postgres password")
 
         if not port:
             port = os.getenv("PORT")


### PR DESCRIPTION
This PR addresses #902 

Changed password existence check from `if not password` to `if password is None` to allow empty string passwords while maintaining the ability to detect unset passwords.