### PR TITLE
sql match bug fix

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -205,7 +205,7 @@ class VannaBase(ABC):
             return sql
 
         # Match SELECT ... ;
-        sqls = re.findall(r"\bSELECT\b .*?;", llm_response, re.DOTALL | re.IGNORECASE)
+        sqls = re.findall(r"\bSELECT.*?;", llm_response, re.DOTALL | re.IGNORECASE)
         if sqls:
             sql = sqls[-1]
             self.log(title="Extracted SQL", message=f"{sql}")


### PR DESCRIPTION
when the sql is like this:

``` sql
SELECT\n    ig.investor_group_id,\n    COUNT(DISTINCT CASE WHEN ch.is_major_shareholder = 1 THEN ch.company_id END) AS num_major_shareholder_banks,\n    COUNT(DISTINCT CASE WHEN ch.shares_held = (\n        SELECT MAX(ch2.shares_held)\n        FROM c_holdings ch2\n        WHERE ch2.company_id = ch.company_id\n    ) AND ch.is_major_shareholder = 1 THEN ch.company_id END) AS num_controlled_banks\nFROM\n    c_investors ig\nJOIN\n    c_holdings ch ON ig.investor_id = ch.investor_id\nWHERE\n    ig.investor_group_id IS NOT NULL\nGROUP BY\n    ig.investor_group_id\nHAVING\n    num_major_shareholder_banks > 2\n    OR num_controlled_banks > 1;
```

this line 
``` python
sqls = re.findall(r"\bSELECT\b .*?;", llm_response, re.DOTALL | re.IGNORECASE)
```
will only match the sub sql like this:
``` sql
SELECT MAX(ch2.shares_held)\n        FROM c_holdings ch2\n        WHERE ch2.company_id = ch.company_id\n    ) AND ch.is_major_shareholder = 1 THEN ch.company_id END) AS num_controlled_banks\nFROM\n    c_investors ig\nJOIN\n    c_holdings ch ON ig.investor_id = ch.investor_id\nWHERE\n    ig.investor_group_id IS NOT NULL\nGROUP BY\n    ig.investor_group_id\nHAVING\n    num_major_shareholder_banks > 2\n    OR num_controlled_banks > 1;
```

this bug is caused by the \n following after the SELECT , which can not be matched by the \b , so we should fix the reg expression like this
``` python
sqls = re.findall(r"\bSELECT.*?;", llm_response, re.DOTALL | re.IGNORECASE)
```
