### PR TITLE
Add Support to Enable/Disable "Thinking" Indicator for Ollama Models

### DIFF
--- a/src/vanna/ollama/ollama.py
+++ b/src/vanna/ollama/ollama.py
@@ -33,6 +33,7 @@ class Ollama(VannaBase):
     self.keep_alive = config.get('keep_alive', None)
     self.ollama_options = config.get('options', {})
     self.num_ctx = self.ollama_options.get('num_ctx', 2048)
+    self.think = config.get('think', True)
     self.__pull_model_if_ne(self.ollama_client, self.model)
 
   @staticmethod
@@ -96,7 +97,8 @@ class Ollama(VannaBase):
                                             messages=prompt,
                                             stream=False,
                                             options=self.ollama_options,
-                                            keep_alive=self.keep_alive)
+                                            keep_alive=self.keep_alive,
+                                            think=self.think)
 
     self.log(f"Ollama Response:\n{str(response_dict)}")
 


### PR DESCRIPTION
This PR introduces a feature that allows users to toggle the "thinking" indicator when using Ollama models.

✨ What's New
Added a value to enable or disable the "think" in config behavior when generating responses with Ollama models. See example below
```
ollama_config = {
    "ollama_host": f"{str(os.environ.get('OLLAMA_BASE_URL', None))}",
    "model": f"{str(os.environ.get('OLLAMA_MODEL', None))}",
    "think": False     # Default is True
}
```

Updated relevant logic to respect this flag.

Maintained backward compatibility by keeping the default behavior unchanged (i.e., "thinking" remains enabled unless explicitly turned off).

📚 Why This Is Useful
When we use thinking model in ollama such as (qwen, deepseek) so it generates thinking content as well that make difficult to parse the json from the response. Now we can turn it off so we will get only the message content from ollama response.

🧪 Testing
Verified that the feature works correctly with the Ollama backend.
Tested both enabled and disabled states to ensure expected behavior.
No impact on non-Ollama models.

**required ollama version >= 0.5.0**