### PR TITLE
Refactor: Removed redundant if example is not None inside else blocks

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -629,10 +629,9 @@ class VannaBase(ABC):
         for example in question_sql_list:
             if example is None:
                 print("example is None")
-            else:
-                if example is not None and "question" in example and "sql" in example:
-                    message_log.append(self.user_message(example["question"]))
-                    message_log.append(self.assistant_message(example["sql"]))
+            elif "question" in example and "sql" in example:
+                message_log.append(self.user_message(example["question"]))
+                message_log.append(self.assistant_message(example["sql"]))
 
         message_log.append(self.user_message(question))
 


### PR DESCRIPTION
The inner if example is not None is redundant since the outer else already guarantees example is not None.
