### PR TITLE
feat: Add RSA key-pair authentication support for Snowflake

### DIFF
--- a/src/vanna/base/base.py
+++ b/src/vanna/base/base.py
@@ -766,6 +766,8 @@ class VannaBase(ABC):
         database: str,
         role: Union[str, None] = None,
         warehouse: Union[str, None] = None,
+        private_key_file: Union[str, None] = None,
+        private_key_file_pwd: Union[str, None] = None,
         **kwargs
     ):
         try:
@@ -785,12 +787,7 @@ class VannaBase(ABC):
                 raise ImproperlyConfigured("Please set your Snowflake username.")
 
         if password == "mypassword":
-            password_env = os.getenv("SNOWFLAKE_PASSWORD")
-
-            if password_env is not None:
-                password = password_env
-            else:
-                raise ImproperlyConfigured("Please set your Snowflake password.")
+            password = os.getenv("SNOWFLAKE_PASSWORD")
 
         if account == "my-account":
             account_env = os.getenv("SNOWFLAKE_ACCOUNT")
@@ -808,14 +805,29 @@ class VannaBase(ABC):
             else:
                 raise ImproperlyConfigured("Please set your Snowflake database.")
 
-        conn = snowflake.connector.connect(
-            user=username,
-            password=password,
-            account=account,
-            database=database,
-            client_session_keep_alive=True,
-            **kwargs
-        )
+        conn_params = {
+            "user": username,
+            "account": account,
+            "database": database,
+            "warehouse": warehouse,
+            "role": role,
+            "client_session_keep_alive": True,
+        }
+
+        if private_key_file:
+            conn_params["authenticator"] = "SNOWFLAKE_JWT"
+            conn_params["private_key_file"] = private_key_file
+            if private_key_file_pwd:
+                conn_params["private_key_file_pwd"] = private_key_file_pwd
+
+        else:
+            if not password:
+                raise ImproperlyConfigured(
+                    "Neither password nor private_key_file provided. Please configure authentication."
+                )
+            conn_params["password"] = password
+
+        conn = snowflake.connector.connect(**conn_params, **kwargs)
 
         def run_sql_snowflake(sql: str) -> pd.DataFrame:
             cs = conn.cursor()


### PR DESCRIPTION
This PR introduces support for key-pair authentication with Snowflake.
Snowflake now enforces key-pair authentication for service accounts and MFA for human accounts.
Defining RSA key-pair authentication provides a secure and straightforward solution for both cases. Particularly helpful since approving MFA prompts for every query can quickly become cumbersome.