### PR TITLE
feat: Added an integration for Azure OpenAI.

### DIFF
--- a/src/vanna/integrations/azureopenai/__init__.py
+++ b/src/vanna/integrations/azureopenai/__init__.py
@@ -1,0 +1,3 @@
+from .llm import AzureOpenAILlmService
+
+__all__ = ["AzureOpenAILlmService"]

--- a/src/vanna/integrations/azureopenai/llm.py
+++ b/src/vanna/integrations/azureopenai/llm.py
@@ -1,0 +1,262 @@
+"""
+Azure OpenAI LLM service integration.
+
+Implement the LlmService interface to interact with Azure OpenAI's
+chat completions API (openai>=1.0.0). Supports non-streaming and streaming text output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, AsyncGenerator, Dict, List, Optional, cast
+
+from vanna.core.llm import (
+    LlmService,
+    LlmRequest,
+    LlmResponse,
+    LlmStreamChunk,
+)
+from vanna.core.tool import ToolCall, ToolSchema
+
+
+class AzureOpenAILlmService(LlmService):
+    """
+    Azure OpenAI LLM service integration.
+
+    Args:
+        api_key: API Key; falls back to env `AZURE_OPENAI_API_KEY`.
+        model: Model name (aka deployment name) to use; falls back to env `AZURE_OPENAI_MODEL`.
+        azure_endpoint: Azure OpenAI endpoint URL; falls back to env `AZURE_OPENAI_ENDPOINT`.
+        api_version: The API version to use; falls back to env `AZURE_OPENAI_API_VERSION`.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        azure_endpoint: Optional[str] = None,
+        api_version: Optional[str] = None,
+        **extra_client_kwargs: Any,
+    ) -> None:
+        try:
+            from openai import AzureOpenAI
+        except Exception as e:  # pragma: no cover
+            raise ImportError(
+                "openai package is required. Install with: pip install 'vanna[openai]'"
+            ) from e
+        self.api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY")
+        self.model = model or os.getenv("AZURE_OPENAI_MODEL")
+        self.azure_endpoint = azure_endpoint or os.getenv("AZURE_OPENAI_ENDPOINT")
+        self.api_version = api_version or os.getenv("AZURE_OPENAI_API_VERSION")
+
+        client_kwargs: Dict[str, Any] = {**extra_client_kwargs}
+        if api_key:
+            client_kwargs["api_key"] = api_key
+        if azure_endpoint:
+            client_kwargs["azure_endpoint"] = azure_endpoint
+        if api_version:
+            client_kwargs["api_version"] = api_version
+
+        self._client = AzureOpenAI(**client_kwargs)
+
+    async def send_request(self, request: LlmRequest) -> LlmResponse:
+        """Send a non-streaming request to Azure OpenAI and return the response."""
+        payload = self._build_payload(request)
+
+        # Call the API synchronously; this function is async but we can block here.
+        resp = self._client.chat.completions.create(**payload, stream=False)
+
+        if not resp.choices:
+            return LlmResponse(content=None, tool_calls=None, finish_reason=None)
+
+        choice = resp.choices[0]
+        content: Optional[str] = getattr(choice.message, "content", None)
+        tool_calls = self._extract_tool_calls_from_message(choice.message)
+
+        usage: Dict[str, int] = {}
+        if getattr(resp, "usage", None):
+            usage = {
+                k: int(v)
+                for k, v in {
+                    "prompt_tokens": getattr(resp.usage, "prompt_tokens", 0),
+                    "completion_tokens": getattr(resp.usage, "completion_tokens", 0),
+                    "total_tokens": getattr(resp.usage, "total_tokens", 0),
+                }.items()
+            }
+
+        return LlmResponse(
+            content=content,
+            tool_calls=tool_calls or None,
+            finish_reason=getattr(choice, "finish_reason", None),
+            usage=usage or None,
+        )
+
+    async def stream_request(
+        self, request: LlmRequest
+    ) -> AsyncGenerator[LlmStreamChunk, None]:
+        """Stream a request to Azure OpenAI.
+
+        Emits `LlmStreamChunk` for textual deltas as they arrive. Tool-calls are
+        accumulated and emitted in a final chunk when the stream ends.
+        """
+        payload = self._build_payload(request)
+
+        # Synchronous streaming iterator; iterate within async context.
+        stream = self._client.chat.completions.create(**payload, stream=True)
+
+        # Builders for streamed tool-calls (index -> partial)
+        tc_builders: Dict[int, Dict[str, Optional[str]]] = {}
+        last_finish: Optional[str] = None
+
+        for event in stream:
+            if not getattr(event, "choices", None):
+                continue
+
+            choice = event.choices[0]
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                # Some SDK versions use `event.choices[0].message` on the final packet
+                last_finish = getattr(choice, "finish_reason", last_finish)
+                continue
+
+            # Text content
+            content_piece: Optional[str] = getattr(delta, "content", None)
+            if content_piece:
+                yield LlmStreamChunk(content=content_piece)
+
+            # Tool calls (streamed)
+            streamed_tool_calls = getattr(delta, "tool_calls", None)
+            if streamed_tool_calls:
+                for tc in streamed_tool_calls:
+                    idx = getattr(tc, "index", 0) or 0
+                    b = tc_builders.setdefault(
+                        idx, {"id": None, "name": None, "arguments": ""}
+                    )
+                    if getattr(tc, "id", None):
+                        b["id"] = tc.id
+                    fn = getattr(tc, "function", None)
+                    if fn is not None:
+                        if getattr(fn, "name", None):
+                            b["name"] = fn.name
+                        if getattr(fn, "arguments", None):
+                            b["arguments"] = (b["arguments"] or "") + fn.arguments
+
+            last_finish = getattr(choice, "finish_reason", last_finish)
+
+        # Emit final tool-calls chunk if any
+        final_tool_calls: List[ToolCall] = []
+        for b in tc_builders.values():
+            if not b.get("name"):
+                continue
+            args_raw = b.get("arguments") or "{}"
+            try:
+                loaded = json.loads(args_raw)
+                if isinstance(loaded, dict):
+                    args_dict: Dict[str, Any] = loaded
+                else:
+                    args_dict = {"args": loaded}
+            except Exception:
+                args_dict = {"_raw": args_raw}
+            final_tool_calls.append(
+                ToolCall(
+                    id=b.get("id") or "tool_call",
+                    name=b["name"] or "tool",
+                    arguments=args_dict,
+                )
+            )
+
+        if final_tool_calls:
+            yield LlmStreamChunk(tool_calls=final_tool_calls, finish_reason=last_finish)
+        else:
+            # Still emit a terminal chunk to signal completion
+            yield LlmStreamChunk(finish_reason=last_finish or "stop")
+
+    async def validate_tools(self, tools: List[ToolSchema]) -> List[str]:
+        """Validate tool schemas. Returns a list of error messages."""
+        errors: List[str] = []
+        # Basic checks; OpenAI will enforce further validation server-side.
+        for t in tools:
+            if not t.name or len(t.name) > 64:
+                errors.append(f"Invalid tool name: {t.name!r}")
+        return errors
+
+    # Internal helpers
+    def _build_payload(self, request: LlmRequest) -> Dict[str, Any]:
+        messages: List[Dict[str, Any]] = []
+
+        # Add system prompt as first message if provided
+        if request.system_prompt:
+            messages.append({"role": "system", "content": request.system_prompt})
+
+        for m in request.messages:
+            msg: Dict[str, Any] = {"role": m.role, "content": m.content}
+            if m.role == "tool" and m.tool_call_id:
+                msg["tool_call_id"] = m.tool_call_id
+            elif m.role == "assistant" and m.tool_calls:
+                # Convert tool calls to OpenAI format
+                tool_calls_payload = []
+                for tc in m.tool_calls:
+                    tool_calls_payload.append(
+                        {
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.name,
+                                "arguments": json.dumps(tc.arguments),
+                            },
+                        }
+                    )
+                msg["tool_calls"] = tool_calls_payload
+            messages.append(msg)
+
+        tools_payload: Optional[List[Dict[str, Any]]] = None
+        if request.tools:
+            tools_payload = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.parameters,
+                    },
+                }
+                for t in request.tools
+            ]
+
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+        }
+        if request.max_tokens is not None:
+            payload["max_tokens"] = request.max_tokens
+        if tools_payload:
+            payload["tools"] = tools_payload
+            payload["tool_choice"] = "auto"
+
+        return payload
+
+    def _extract_tool_calls_from_message(self, message: Any) -> List[ToolCall]:
+        tool_calls: List[ToolCall] = []
+        raw_tool_calls = getattr(message, "tool_calls", None) or []
+        for tc in raw_tool_calls:
+            fn = getattr(tc, "function", None)
+            if not fn:
+                continue
+            args_raw = getattr(fn, "arguments", "{}")
+            try:
+                loaded = json.loads(args_raw)
+                if isinstance(loaded, dict):
+                    args_dict: Dict[str, Any] = loaded
+                else:
+                    args_dict = {"args": loaded}
+            except Exception:
+                args_dict = {"_raw": args_raw}
+            tool_calls.append(
+                ToolCall(
+                    id=getattr(tc, "id", "tool_call"),
+                    name=getattr(fn, "name", "tool"),
+                    arguments=args_dict,
+                )
+            )
+        return tool_calls

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ def pytest_configure(config):
         "markers", "anthropic: marks tests requiring Anthropic API key"
     )
     config.addinivalue_line("markers", "openai: marks tests requiring OpenAI API key")
+    config.addinivalue_line(
+        "markers", "azureopenai: marks tests requiring Azure OpenAI API key"
+    )
     config.addinivalue_line("markers", "gemini: marks tests requiring Google API key")
     config.addinivalue_line("markers", "ollama: marks tests requiring Ollama")
     config.addinivalue_line("markers", "chromadb: marks tests requiring ChromaDB")
@@ -41,6 +44,15 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(
                     pytest.mark.skip(
                         reason="OPENAI_API_KEY environment variable not set"
+                    )
+                )
+
+        # Skip Azure OpenAI tests if no API key
+        if "azureopenai" in item.keywords:
+            if not os.getenv("AZURE_OPENAI_API_KEY"):
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="AZURE_OPENAI_API_KEY environment variable not set"
                     )
                 )
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -131,6 +131,28 @@ async def test_openai_top_artist(chinook_db):
     await test_agent_top_artist(agent)
 
 
+@pytest.mark.azureopenai
+@pytest.mark.asyncio
+async def test_azure_openai_top_artist(chinook_db):
+    """Test Azure OpenAI agent finding the top artist by sales."""
+    from vanna.integrations.azureopenai import AzureOpenAILlmService
+
+    api_key = os.getenv("AZURE_OPENAI_API_KEY")
+    model = os.getenv("AZURE_OPENAI_MODEL")
+    azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+    api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+
+    llm = AzureOpenAILlmService(
+        api_key=api_key,
+        model=model,
+        azure_endpoint=azure_endpoint,
+        api_version=api_version,
+    )
+
+    agent = create_agent(llm, chinook_db)
+    await test_agent_top_artist(agent)
+
+
 # @pytest.mark.openai
 # @pytest.mark.asyncio
 # async def test_openai_responses_top_artist(chinook_db):


### PR DESCRIPTION
### Summary
---
This PR adds an integration for Azure OpenAI. Requires an api key, azure endpoint, api version, and model name. This approach is in-line with the legacy Azure OpenAI integration and follows the `openai.AzureOpenAI` class.

#### Changes 
* Implements AzureOpenAILlmService class
* Adds test for Azure OpenAI agent. Also sets a mark for Azure OpenAI testing.

#### Testing
* All tests with no external dependencies are passing.
* I was also able to successfully use this integration in a local deployment of the vanna UI and service.
* The only issue is I can't seem to get the unit test to pass with the `azureopenai` marker. It seems like it doesn't recognize the schema and database layout of the chinook db. I don't have any other API keys handy so wasn't sure if this is also affecting other models like anthropic or openai.