### PR TITLE
Add Apache Doris database support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ servers = ["vanna[flask,fastapi]"]
 
 postgres = ["psycopg2-binary", "db-dtypes"]
 mysql = ["PyMySQL"]
+doris = ["PyMySQL"]
 clickhouse = ["clickhouse_connect"]
 bigquery = ["google-cloud-bigquery"]
 snowflake = ["snowflake-connector-python"]

--- a/src/vanna/integrations/doris/__init__.py
+++ b/src/vanna/integrations/doris/__init__.py
@@ -1,0 +1,5 @@
+"""Apache Doris integration for Vanna."""
+
+from .sql_runner import DorisRunner
+
+__all__ = ["DorisRunner"]

--- a/src/vanna/integrations/doris/sql_runner.py
+++ b/src/vanna/integrations/doris/sql_runner.py
@@ -1,0 +1,95 @@
+"""Apache Doris implementation of SqlRunner interface."""
+
+import pandas as pd
+
+from vanna.capabilities.sql_runner import SqlRunner, RunSqlToolArgs
+from vanna.core.tool import ToolContext
+
+
+class DorisRunner(SqlRunner):
+    """Apache Doris implementation of the SqlRunner interface.
+
+    Apache Doris is MySQL-compatible, so this implementation uses PyMySQL
+    as the database driver with Doris-specific defaults (port 9030).
+    """
+
+    def __init__(
+        self,
+        host: str,
+        database: str,
+        user: str,
+        password: str,
+        port: int = 9030,
+        **kwargs,
+    ):
+        """Initialize with Apache Doris connection parameters.
+
+        Args:
+            host: Database host address
+            database: Database name
+            user: Database user
+            password: Database password
+            port: Database port (default: 9030, Doris FE query port)
+            **kwargs: Additional PyMySQL connection parameters
+        """
+        try:
+            import pymysql.cursors
+
+            self.pymysql = pymysql
+        except ImportError as e:
+            raise ImportError(
+                "PyMySQL package is required. Install with: pip install 'vanna[doris]'"
+            ) from e
+
+        self.host = host
+        self.database = database
+        self.user = user
+        self.password = password
+        self.port = port
+        self.kwargs = kwargs
+
+    async def run_sql(self, args: RunSqlToolArgs, context: ToolContext) -> pd.DataFrame:
+        """Execute SQL query against Apache Doris database and return results as DataFrame.
+
+        Args:
+            args: SQL query arguments
+            context: Tool execution context
+
+        Returns:
+            DataFrame with query results
+
+        Raises:
+            pymysql.Error: If query execution fails
+        """
+        # Connect to the database
+        conn = self.pymysql.connect(
+            host=self.host,
+            user=self.user,
+            password=self.password,
+            database=self.database,
+            port=self.port,
+            cursorclass=self.pymysql.cursors.DictCursor,
+            **self.kwargs,
+        )
+
+        try:
+            # Ping to ensure connection is alive
+            conn.ping(reconnect=True)
+
+            cursor = conn.cursor()
+            cursor.execute(args.sql)
+            results = cursor.fetchall()
+
+            # Create a pandas dataframe from the results
+            df = pd.DataFrame(
+                results,
+                columns=[desc[0] for desc in cursor.description]
+                if cursor.description
+                else [],
+            )
+
+            cursor.close()
+            return df
+
+        finally:
+            conn.close()

--- a/tests/test_database_sanity.py
+++ b/tests/test_database_sanity.py
@@ -501,6 +501,54 @@ class TestMySQLRunner:
         assert runner.host == "localhost"
 
 
+class TestDorisRunner:
+    """Sanity tests for DorisRunner implementation."""
+
+    def test_doris_runner_import(self):
+        """Test that DorisRunner can be imported."""
+        from vanna.integrations.doris import DorisRunner
+
+        assert DorisRunner is not None
+
+    def test_doris_runner_implements_sql_runner(self):
+        """Test that DorisRunner implements SqlRunner interface."""
+        from vanna.integrations.doris import DorisRunner
+        from vanna.capabilities.sql_runner import SqlRunner
+
+        assert issubclass(DorisRunner, SqlRunner)
+
+    def test_doris_runner_has_run_sql_method(self):
+        """Test that DorisRunner implements run_sql method."""
+        from vanna.integrations.doris import DorisRunner
+
+        assert hasattr(DorisRunner, "run_sql")
+        assert not getattr(DorisRunner.run_sql, "__isabstractmethod__", False)
+
+    def test_doris_runner_instantiation(self):
+        """Test that DorisRunner can be instantiated with required parameters."""
+        from vanna.integrations.doris import DorisRunner
+
+        runner = DorisRunner(
+            host="localhost", database="test-db", user="test-user", password="test-pass"
+        )
+        assert runner is not None
+        assert runner.host == "localhost"
+        assert runner.port == 9030  # Default Doris port
+
+    def test_doris_runner_custom_port(self):
+        """Test that DorisRunner can be instantiated with custom port."""
+        from vanna.integrations.doris import DorisRunner
+
+        runner = DorisRunner(
+            host="localhost",
+            database="test-db",
+            user="test-user",
+            password="test-pass",
+            port=9031,
+        )
+        assert runner.port == 9031
+
+
 class TestClickHouseRunner:
     """Sanity tests for ClickHouseRunner implementation."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
     py311-sqlite-sanity
     py311-snowflake-sanity
     py311-mysql-sanity
+    py311-doris-sanity
     py311-clickhouse-sanity
     py311-oracle-sanity
     py311-bigquery-sanity
@@ -157,6 +158,16 @@ extras = mysql
 commands =
     python -c "from vanna.integrations.mysql import MySQLRunner; print('✓ MySQLRunner import successful')"
     pytest tests/test_database_sanity.py::TestMySQLRunner -v
+
+[testenv:py311-doris-sanity]
+description = Sanity tests for Apache Doris implementation
+deps =
+    pytest>=7.0.0
+    pytest-asyncio>=0.21.0
+extras = doris
+commands =
+    python -c "from vanna.integrations.doris import DorisRunner; print('✓ DorisRunner import successful')"
+    pytest tests/test_database_sanity.py::TestDorisRunner -v
 
 [testenv:py311-clickhouse-sanity]
 description = Sanity tests for ClickHouse implementation


### PR DESCRIPTION
- Add DorisRunner class implementing SqlRunner interface
- Add legacy connect_to_doris() method to VannaBase
- Add doris optional dependency (PyMySQL)
- Add comprehensive sanity tests for DorisRunner
- Add tox environment for doris sanity tests
- Default port: 9030 (Doris FE query port)
- Tested against real Doris instance with 6M rows