### PR TITLE
feat: add custom headers property to web component

### DIFF
--- a/frontends/webcomponent/src/components/vanna-chat.ts
+++ b/frontends/webcomponent/src/components/vanna-chat.ts
@@ -717,6 +717,7 @@ export class VannaChat extends LitElement {
   @property({ attribute: 'sse-endpoint' }) sseEndpoint = '/api/vanna/v2/chat_sse';
   @property({ attribute: 'ws-endpoint' }) wsEndpoint = '/api/vanna/v2/chat_websocket';
   @property({ attribute: 'poll-endpoint' }) pollEndpoint = '/api/vanna/v2/chat_poll';
+  @property({ type: Object, attribute: 'custom-headers' }) customHeaders: Record<string, string> = {};
   @property() subtitle = '';
   @property() startingState: 'normal' | 'maximized' | 'minimized' = 'normal';
 
@@ -847,6 +848,12 @@ export class VannaChat extends LitElement {
       this.classList.add(this._windowState);
       console.log('Applied CSS classes:', this.className);
     }
+
+	if (changedProperties.has('customHeaders')) {
+		console.log('customHeaders changed.');
+		this.apiClient.setCustomHeaders(this.customHeaders);
+		console.log('Custom headers updated.');
+	}
   }
 
   private handleInput(e: Event) {


### PR DESCRIPTION
- Adds the `customHeaders` Object property to the Web Component to allow to configuring custom headers to be accessible during web component initialization like the endpoints are.
- Will update the custom headers on the api client when they are changed

Why:

We are embedding the Web Component into our Angular application using the NPM package, when it gets rendered I want to be able to pass the necessary custom headers down to the Web Component during initialization so that they are available right away.