### PR TITLE
Implement #1085: add support to Vertex AI endpoint in GeminiLlmService class

### DIFF
--- a/src/vanna/integrations/google/gemini.py
+++ b/src/vanna/integrations/google/gemini.py
@@ -41,6 +41,7 @@ class GeminiLlmService(LlmService):
         model: Optional[str] = None,
         api_key: Optional[str] = None,
         temperature: float = 0.7,
+        vertexai: Optional[bool] = None,
         **extra_config: Any,
     ) -> None:
         try:
@@ -67,7 +68,7 @@ class GeminiLlmService(LlmService):
         self._types = types
 
         # Create client
-        self._client = genai.Client(api_key=api_key)
+        self._client = genai.Client(api_key=api_key, vertexai=vertexai)
 
         # Store generation config
         self.temperature = temperature


### PR DESCRIPTION
Implement #1085 

- Updated the GeminiLlmService constructor to accept `vertexai` argument and use it to instantiate let the google library call the Vertex AI enpoints
