### PR TITLE
feat: Add Forge LLM provider support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = ["pytest>=7.0.0", "pytest-asyncio>=0.21.0", "pytest-mock>=3.10.0", "pytes
 dev = ["pytest>=7.0.0", "pytest-asyncio>=0.21.0", "pytest-mock>=3.10.0", "pytest-cov>=4.0.0", "tox>=4.0.0", "mypy", "ruff", "pandas-stubs", "plotly-stubs", "types-PyYAML", "types-requests", "types-tabulate"]
 chromadb = ["chromadb>=1.1.0"]
 openai = ["openai"]
+forge = ["openai"]
 azureopenai = ["openai", "azure-identity"]
 qianfan = ["qianfan"]
 mistralai = ["mistralai>=1.0.0"]
@@ -103,6 +104,7 @@ markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "anthropic: marks tests requiring Anthropic API key",
     "openai: marks tests requiring OpenAI API key",
+    "forge: marks tests requiring Forge API key",
     "azureopenai: marks tests requiring Azure OpenAI API key",
     "gemini: marks tests requiring Gemini API key",
     "ollama: marks tests requiring local Ollama instance",

--- a/src/vanna/integrations/forge/__init__.py
+++ b/src/vanna/integrations/forge/__init__.py
@@ -1,0 +1,9 @@
+"""
+Forge integration.
+
+This module provides a Forge LLM service implementation.
+"""
+
+from .llm import ForgeLlmService
+
+__all__ = ["ForgeLlmService"]

--- a/src/vanna/integrations/forge/llm.py
+++ b/src/vanna/integrations/forge/llm.py
@@ -1,0 +1,55 @@
+"""
+Forge LLM service implementation.
+
+Forge is an OpenAI API compatible LLM router that provides unified access to
+multiple AI providers through a single API. This service extends the OpenAI
+implementation with Forge-specific defaults.
+
+See https://github.com/TensorBlock/forge for details.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from vanna.integrations.openai.llm import OpenAILlmService
+
+
+class ForgeLlmService(OpenAILlmService):
+    """Forge-backed LLM service.
+
+    Extends ``OpenAILlmService`` with Forge-specific defaults for base URL,
+    API key, and model name. Forge uses the standard OpenAI API format so all
+    streaming, tool-calling, and response handling from the parent class work
+    unchanged.
+
+    Args:
+        model: Model name in ``Provider/model-name`` format
+            (e.g., ``"OpenAI/gpt-4o"``). Falls back to env
+            ``FORGE_MODEL`` then ``"OpenAI/gpt-4o-mini"``.
+        api_key: Forge API key; falls back to env ``FORGE_API_KEY``.
+        base_url: Optional custom base URL; falls back to env
+            ``FORGE_API_BASE`` then ``"https://api.forge.tensorblock.co/v1"``.
+        **extra_client_kwargs: Extra kwargs forwarded to ``openai.OpenAI()``.
+    """
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **extra_client_kwargs: Any,
+    ) -> None:
+        api_key = api_key or os.getenv("FORGE_API_KEY")
+        base_url = base_url or os.getenv(
+            "FORGE_API_BASE", "https://api.forge.tensorblock.co/v1"
+        )
+        model = model or os.getenv("FORGE_MODEL", "OpenAI/gpt-4o-mini")
+
+        super().__init__(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            **extra_client_kwargs,
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,14 @@ commands =
     python -c "from vanna.integrations.openai import OpenAILlmService; print('✓ OpenAI import successful')"
     pytest tests/ -v -m openai
 
+[testenv:py311-forge]
+description = Test with Forge
+extras = forge
+passenv = FORGE_API_KEY
+commands =
+    python -c "from vanna.integrations.forge import ForgeLlmService; print('✓ Forge import successful')"
+    pytest tests/ -v -m forge
+
 ; [testenv:py311-gemini]
 ; description = Test with Google Gemini
 ; extras = gemini


### PR DESCRIPTION
## Changes

- Added ForgeLlmService subclassing OpenAILlmService in src/vanna/integrations/forge/, added forge optional dependency in pyproject.toml
- Environment variable: FORGE_API_KEY
- Base URL: https://api.forge.tensorblock.co/v1
- Model format: Provider/model-name (e.g., OpenAI/gpt-4o)
- Non-breaking: purely additive, existing providers are untouched

## About Forge

Forge (https://github.com/TensorBlock/forge) is an open-source middleware that routes inference across 40+ upstream providers (including OpenAI, Anthropic, Gemini, DeepSeek, and OpenRouter). It is OpenAI API compatible — works with the standard OpenAI SDK by changing base_url and api_key.

## Motivation

We have seen growing interest from users who standardize on Forge for their model management and want to use it natively with Vanna. This integration aims to bridge that gap.

## Key Benefits

- Self-Hosted & Privacy-First: Forge is open-source and designed to be self-hosted, critical for users who require data sovereignty
- Future-Proofing: acts as a decoupling layer — instead of maintaining individual adapters for every new provider, Forge users can access them immediately
- Compatibility: supports established aggregators (like OpenRouter) as well as direct provider connections (BYOK)

## References

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview
- Main Page: https://www.tensorblock.co/