### PR TITLE
Fix #1069 #1073 #1078 #190 + RetryLlmService, CachingLlmService, LoggingObservabilityProvider + 58 new tests

### DIFF
--- a/src/vanna/core/agent/agent.py
+++ b/src/vanna/core/agent/agent.py
@@ -17,6 +17,7 @@ from vanna.components import (
     TaskTrackerUpdateComponent,
     ChatInputUpdateComponent,
     StatusCardComponent,
+    StatusIndicatorComponent,
     Task,
 )
 from .config import AgentConfig
@@ -645,8 +646,13 @@ class Agent:
 
         while tool_iterations < self.config.max_tool_iterations:
             if self.config.include_thinking_indicators and tool_iterations == 0:
-                # TODO: Yield thinking indicator
-                pass
+                yield UiComponent(  # type: ignore
+                    rich_component=StatusIndicatorComponent(
+                        status="loading",
+                        message="Thinking...",
+                        pulse=True,
+                    )
+                )
 
             # Get LLM response
             if self.config.stream_responses:

--- a/src/vanna/core/tool/models.py
+++ b/src/vanna/core/tool/models.py
@@ -23,6 +23,11 @@ class ToolCall(BaseModel):
     id: str = Field(description="Unique identifier for this tool call")
     name: str = Field(description="Name of the tool to execute")
     arguments: Dict[str, Any] = Field(description="Raw arguments from LLM")
+    thought_signature: Optional[bytes] = Field(
+        default=None,
+        description="Opaque thought signature required by some LLMs (e.g. Gemini 3) "
+        "to correctly process function call results in subsequent turns.",
+    )
 
 
 class ToolContext(BaseModel):

--- a/src/vanna/integrations/local/__init__.py
+++ b/src/vanna/integrations/local/__init__.py
@@ -5,13 +5,19 @@ This module provides built-in local implementations.
 """
 
 from .audit import LoggingAuditLogger
+from .caching_llm import CachingLlmService
 from .file_system import LocalFileSystem
-from .storage import MemoryConversationStore
 from .file_system_conversation_store import FileSystemConversationStore
+from .logging_observability import LoggingObservabilityProvider
+from .retry_llm import RetryLlmService
+from .storage import MemoryConversationStore
 
 __all__ = [
-    "MemoryConversationStore",
+    "CachingLlmService",
     "FileSystemConversationStore",
     "LocalFileSystem",
     "LoggingAuditLogger",
+    "LoggingObservabilityProvider",
+    "MemoryConversationStore",
+    "RetryLlmService",
 ]

--- a/src/vanna/integrations/local/caching_llm.py
+++ b/src/vanna/integrations/local/caching_llm.py
@@ -1,0 +1,130 @@
+"""
+CachingLlmService — LlmService wrapper with in-memory response caching.
+
+Caches deterministic, non-tool-call LlmResponses so repeated identical
+queries never hit the upstream LLM API, reducing cost and latency.
+
+Responses that contain tool_calls are intentionally NOT cached because
+tool calls may carry provider-specific state (e.g. Gemini thought_signature).
+Streaming requests are also never cached.
+
+Usage::
+
+    from vanna.integrations.anthropic import AnthropicLlmService
+    from vanna.integrations.local.caching_llm import CachingLlmService
+
+    base_llm = AnthropicLlmService(api_key="...")
+    llm = CachingLlmService(base_llm, max_size=256)
+    agent = Agent(llm_service=llm, ...)
+
+    # Inspect stats
+    print(llm.stats)   # {"hits": 3, "misses": 10, "size": 10}
+    llm.invalidate()   # clear all cached entries
+"""
+
+import hashlib
+import json
+import logging
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+from vanna.core.llm import LlmRequest, LlmResponse, LlmService, LlmStreamChunk
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_key(request: LlmRequest) -> str:
+    """Compute a deterministic SHA-256 key for an LlmRequest.
+
+    Includes system_prompt, messages, tools, temperature, and max_tokens.
+    The ``user`` field and ``metadata`` are intentionally excluded so that
+    two users sending the same question share cached answers.
+    """
+    key_data = {
+        "system_prompt": request.system_prompt,
+        "messages": [
+            {"role": m.role, "content": m.content} for m in request.messages
+        ],
+        "tools": [
+            t.model_dump() if hasattr(t, "model_dump") else str(t)
+            for t in (request.tools or [])
+        ],
+        "temperature": request.temperature,
+        "max_tokens": request.max_tokens,
+    }
+    serialized = json.dumps(key_data, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+class CachingLlmService(LlmService):
+    """LlmService decorator with an LRU-style in-memory response cache.
+
+    Args:
+        inner: The underlying LlmService to wrap.
+        max_size: Maximum number of entries to keep. When the cache is full,
+            the oldest entry (insertion order) is evicted. ``None`` means
+            unlimited (not recommended for long-running servers).
+    """
+
+    def __init__(
+        self,
+        inner: LlmService,
+        max_size: Optional[int] = 512,
+    ) -> None:
+        self.inner = inner
+        self.max_size = max_size
+        self._cache: Dict[str, LlmResponse] = {}
+        self._hits = 0
+        self._misses = 0
+
+    @property
+    def stats(self) -> Dict[str, int]:
+        """Return cache hit/miss/size counters."""
+        return {
+            "hits": self._hits,
+            "misses": self._misses,
+            "size": len(self._cache),
+        }
+
+    def invalidate(self) -> None:
+        """Evict all cached entries."""
+        self._cache.clear()
+        logger.debug("Cache invalidated")
+
+    def _evict_if_full(self) -> None:
+        if self.max_size and len(self._cache) >= self.max_size:
+            oldest = next(iter(self._cache))
+            del self._cache[oldest]
+            logger.debug("Cache evicted oldest entry (max_size=%d)", self.max_size)
+
+    async def send_request(self, request: LlmRequest) -> LlmResponse:
+        key = _cache_key(request)
+
+        if key in self._cache:
+            self._hits += 1
+            logger.debug("Cache HIT  (key=%.8s, hits=%d)", key, self._hits)
+            return self._cache[key]
+
+        self._misses += 1
+        logger.debug("Cache MISS (key=%.8s, misses=%d)", key, self._misses)
+
+        response = await self.inner.send_request(request)
+
+        # Only cache pure-text responses — tool-call responses carry state.
+        if not response.tool_calls:
+            self._evict_if_full()
+            self._cache[key] = response
+            logger.debug(
+                "Cached response (key=%.8s, cache_size=%d)", key, len(self._cache)
+            )
+
+        return response
+
+    async def stream_request(
+        self, request: LlmRequest
+    ) -> AsyncGenerator[LlmStreamChunk, None]:
+        # Streaming responses are never cached — pass through unchanged.
+        async for chunk in self.inner.stream_request(request):
+            yield chunk
+
+    async def validate_tools(self, tools: List[Any]) -> List[str]:
+        return await self.inner.validate_tools(tools)

--- a/src/vanna/integrations/local/logging_observability.py
+++ b/src/vanna/integrations/local/logging_observability.py
@@ -1,0 +1,126 @@
+"""
+LoggingObservabilityProvider — ObservabilityProvider backed by Python logging.
+
+Writes span lifecycle events and metric measurements to Python's standard
+logging module. Zero external dependencies — useful for development,
+testing, and lightweight production deployments that already ship logs
+to a log aggregation system (e.g., CloudWatch, Datadog log agent).
+
+Usage::
+
+    from vanna.integrations.local.logging_observability import LoggingObservabilityProvider
+
+    obs = LoggingObservabilityProvider()
+    agent = Agent(llm_service=..., observability_provider=obs)
+
+Log format examples::
+
+    [SPAN START] agent_comparison | id=3f2a... | {"num_variants": 2}
+    [SPAN END]   agent_comparison | id=3f2a... | duration=142.3ms | {"num_variants": 2}
+    [METRIC]     agent.request.duration=342.1ms | tags={"variant": "gpt-4"}
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from vanna.core.observability import ObservabilityProvider
+from vanna.core.observability.models import Span
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingObservabilityProvider(ObservabilityProvider):
+    """ObservabilityProvider that writes spans and metrics to Python logging.
+
+    Args:
+        span_log_level: Log level for span events (default: DEBUG).
+        metric_log_level: Log level for metric events (default: DEBUG).
+    """
+
+    def __init__(
+        self,
+        span_log_level: int = logging.DEBUG,
+        metric_log_level: int = logging.DEBUG,
+    ) -> None:
+        self.span_log_level = span_log_level
+        self.metric_log_level = metric_log_level
+
+    async def create_span(
+        self, name: str, attributes: Optional[Dict[str, Any]] = None
+    ) -> Span:
+        """Create and log a new span.
+
+        Args:
+            name: Span name / operation label.
+            attributes: Optional key-value attributes to attach to the span.
+
+        Returns:
+            A new :class:`Span` instance.
+        """
+        span = Span(name=name, attributes=attributes or {})
+        attrs_str = _fmt_attrs(span.attributes)
+        logger.log(
+            self.span_log_level,
+            "[SPAN START] %s | id=%.8s%s",
+            name,
+            span.id,
+            f" | {attrs_str}" if attrs_str else "",
+        )
+        return span
+
+    async def end_span(self, span: Span) -> None:
+        """End a span and log its duration.
+
+        Args:
+            span: The span to end.
+        """
+        span.end()
+        duration = span.duration_ms()
+        duration_str = f"{duration:.1f}ms" if duration is not None else "n/a"
+        attrs_str = _fmt_attrs(span.attributes)
+        logger.log(
+            self.span_log_level,
+            "[SPAN END]   %s | id=%.8s | duration=%s%s",
+            span.name,
+            span.id,
+            duration_str,
+            f" | {attrs_str}" if attrs_str else "",
+        )
+
+    async def record_metric(
+        self,
+        name: str,
+        value: float,
+        unit: str = "",
+        tags: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Log a metric measurement.
+
+        Args:
+            name: Metric name (e.g., ``"agent.request.duration"``).
+            value: Numeric value.
+            unit: Unit of measurement (e.g., ``"ms"``, ``"tokens"``).
+            tags: Optional string key-value tags.
+        """
+        value_str = f"{value}{unit}" if unit else str(value)
+        tags_str = f" | tags={tags}" if tags else ""
+        logger.log(
+            self.metric_log_level,
+            "[METRIC]     %s=%s%s",
+            name,
+            value_str,
+            tags_str,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fmt_attrs(attrs: Dict[str, Any]) -> str:
+    """Return a compact string representation of span attributes, or ''."""
+    if not attrs:
+        return ""
+    parts = [f"{k}={v!r}" for k, v in attrs.items()]
+    return "{" + ", ".join(parts) + "}"

--- a/src/vanna/integrations/local/retry_llm.py
+++ b/src/vanna/integrations/local/retry_llm.py
@@ -1,0 +1,139 @@
+"""
+RetryLlmService — LlmService wrapper with exponential-backoff retry.
+
+Retries transient failures (network timeouts, 429 rate-limits, 5xx errors)
+so a single blip doesn't crash the whole agent run.
+
+Usage::
+
+    from vanna.integrations.anthropic import AnthropicLlmService
+    from vanna.integrations.local.retry_llm import RetryLlmService
+
+    base_llm = AnthropicLlmService(api_key="...")
+    llm = RetryLlmService(base_llm, max_retries=3)
+    agent = Agent(llm_service=llm, ...)
+"""
+
+import asyncio
+import logging
+import random
+from typing import Any, AsyncGenerator, List, Optional, Tuple, Type
+
+from vanna.core.llm import LlmRequest, LlmResponse, LlmService, LlmStreamChunk
+
+logger = logging.getLogger(__name__)
+
+# httpx is a core dependency of vanna; import lazily so the module can be
+# imported even in environments where httpx isn't on sys.path yet.
+_RETRYABLE_EXCEPTIONS: Tuple[Type[Exception], ...] = ()
+
+try:
+    import httpx
+
+    _RETRYABLE_EXCEPTIONS = (
+        httpx.TimeoutException,
+        httpx.ConnectError,
+        httpx.RemoteProtocolError,
+    )
+except ImportError:  # pragma: no cover
+    pass
+
+# HTTP status codes that are safe to retry
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """Return True if the exception represents a transient failure."""
+    if _RETRYABLE_EXCEPTIONS and isinstance(exc, _RETRYABLE_EXCEPTIONS):
+        return True
+    # Handle httpx.HTTPStatusError and similar wrappers
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status = getattr(response, "status_code", None)
+        if status in _RETRYABLE_STATUS_CODES:
+            return True
+    return False
+
+
+class RetryLlmService(LlmService):
+    """LlmService decorator that retries transient failures with exponential backoff.
+
+    Args:
+        inner: The underlying LlmService to wrap.
+        max_retries: Maximum number of retry attempts (default 3).
+        base_delay: Initial backoff delay in seconds (default 1.0).
+        max_delay: Maximum backoff delay in seconds (default 30.0).
+        jitter: Apply ±50 % random jitter to each delay (default True).
+    """
+
+    def __init__(
+        self,
+        inner: LlmService,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+        max_delay: float = 30.0,
+        jitter: bool = True,
+    ) -> None:
+        self.inner = inner
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.jitter = jitter
+
+    def _delay(self, attempt: int) -> float:
+        delay = min(self.base_delay * (2**attempt), self.max_delay)
+        if self.jitter:
+            delay *= random.uniform(0.5, 1.5)
+        return delay
+
+    async def send_request(self, request: LlmRequest) -> LlmResponse:
+        for attempt in range(self.max_retries + 1):
+            try:
+                return await self.inner.send_request(request)
+            except Exception as exc:
+                if not _is_retryable(exc) or attempt == self.max_retries:
+                    raise
+                delay = self._delay(attempt)
+                logger.warning(
+                    "LLM send_request failed (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1,
+                    self.max_retries + 1,
+                    delay,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+        raise RuntimeError("Unreachable")  # pragma: no cover
+
+    async def stream_request(
+        self, request: LlmRequest
+    ) -> AsyncGenerator[LlmStreamChunk, None]:
+        """Retry stream only if the error occurs before any chunks are yielded.
+
+        Once chunks have started flowing, re-raising is the only safe option
+        because the caller may already have accumulated partial content.
+        """
+        for attempt in range(self.max_retries + 1):
+            chunks_yielded = 0
+            try:
+                async for chunk in self.inner.stream_request(request):
+                    chunks_yielded += 1
+                    yield chunk
+                return  # stream completed successfully
+            except Exception as exc:
+                # If data already started, propagate immediately — retrying
+                # would produce duplicate chunks in the caller's accumulator.
+                if chunks_yielded > 0 or not _is_retryable(exc) or attempt == self.max_retries:
+                    raise
+                delay = self._delay(attempt)
+                logger.warning(
+                    "LLM stream_request failed before first chunk "
+                    "(attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1,
+                    self.max_retries + 1,
+                    delay,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+
+    async def validate_tools(self, tools: List[Any]) -> List[str]:
+        return await self.inner.validate_tools(tools)

--- a/src/vanna/legacy/flask/__init__.py
+++ b/src/vanna/legacy/flask/__init__.py
@@ -534,6 +534,14 @@ class VannaFlaskAPI:
                         }
                     )
 
+                if not vn.is_sql_valid(sql=sql):
+                    return jsonify(
+                        {
+                            "type": "error",
+                            "error": "SQL validation failed. Only SELECT statements are allowed by default. Override is_sql_valid() to enable other statement types.",
+                        }
+                    )
+
                 df = vn.run_sql(sql=sql)
 
                 self.cache.set(id=id, field="df", value=df)

--- a/src/vanna/servers/fastapi/app.py
+++ b/src/vanna/servers/fastapi/app.py
@@ -34,11 +34,13 @@ class VannaFastAPIServer:
             Configured FastAPI application
         """
         # Create FastAPI app
-        app_config = self.config.get("fastapi", {})
+        app_config = dict(self.config.get("fastapi", {}))
         app = FastAPI(
-            title="Vanna Agents API",
-            description="API server for Vanna Agents framework",
-            version="0.1.0",
+            title=app_config.pop("title", "Vanna Agents API"),
+            description=app_config.pop(
+                "description", "API server for Vanna Agents framework"
+            ),
+            version=app_config.pop("version", "0.1.0"),
             **app_config,
         )
 

--- a/tests/test_local_wrappers.py
+++ b/tests/test_local_wrappers.py
@@ -1,0 +1,406 @@
+"""
+Unit tests for Phase-3 local wrappers:
+
+- RetryLlmService  (integrations/local/retry_llm.py)
+- CachingLlmService (integrations/local/caching_llm.py)
+- LoggingObservabilityProvider (integrations/local/logging_observability.py)
+
+All tests are fully offline — no real LLM API calls are made.
+"""
+
+import asyncio
+import logging
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from vanna.core.llm import LlmMessage, LlmRequest, LlmResponse
+from vanna.core.llm.models import LlmStreamChunk
+from vanna.integrations.local.caching_llm import CachingLlmService, _cache_key
+from vanna.integrations.local.logging_observability import LoggingObservabilityProvider
+from vanna.integrations.local.retry_llm import RetryLlmService, _is_retryable
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(content: str = "Hello") -> LlmRequest:
+    from vanna.core.user import User
+
+    user = User(
+        id="u1",
+        username="tester",
+        email="t@example.com",
+        group_memberships=[],
+    )
+    return LlmRequest(
+        messages=[LlmMessage(role="user", content=content)],
+        user=user,
+        metadata={},
+    )
+
+
+def _make_response(content: str = "Hi", tool_calls=None) -> LlmResponse:
+    return LlmResponse(content=content, tool_calls=tool_calls)
+
+
+def _make_inner(response: LlmResponse) -> MagicMock:
+    """Create a mock LlmService that returns *response* on send_request."""
+    inner = MagicMock()
+    inner.send_request = AsyncMock(return_value=response)
+    inner.validate_tools = AsyncMock(return_value=[])
+    return inner
+
+
+# ---------------------------------------------------------------------------
+# RetryLlmService
+# ---------------------------------------------------------------------------
+
+
+class TestRetryLlmService:
+    """Tests for RetryLlmService."""
+
+    @pytest.mark.asyncio
+    async def test_success_on_first_attempt(self):
+        """No retry needed — returns response immediately."""
+        resp = _make_response("OK")
+        inner = _make_inner(resp)
+        svc = RetryLlmService(inner, max_retries=3)
+        result = await svc.send_request(_make_request())
+        assert result.content == "OK"
+        assert inner.send_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_retryable_error_then_succeeds(self):
+        """Retries after a retryable error and succeeds on the third attempt."""
+        try:
+            import httpx
+        except ImportError:
+            pytest.skip("httpx not installed")
+
+        resp = _make_response("Eventually")
+        inner = MagicMock()
+        inner.send_request = AsyncMock(
+            side_effect=[
+                httpx.TimeoutException("timeout"),
+                httpx.TimeoutException("timeout"),
+                resp,
+            ]
+        )
+        svc = RetryLlmService(inner, max_retries=3, base_delay=0, jitter=False)
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await svc.send_request(_make_request())
+        assert result.content == "Eventually"
+        assert inner.send_request.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries_exhausted(self):
+        """Raises the last exception when max_retries is exhausted."""
+        try:
+            import httpx
+        except ImportError:
+            pytest.skip("httpx not installed")
+
+        inner = MagicMock()
+        inner.send_request = AsyncMock(
+            side_effect=httpx.TimeoutException("always fails")
+        )
+        svc = RetryLlmService(inner, max_retries=2, base_delay=0, jitter=False)
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(httpx.TimeoutException):
+                await svc.send_request(_make_request())
+        # 1 initial + 2 retries = 3 total calls
+        assert inner.send_request.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_non_retryable_error(self):
+        """ValueError is not retryable — raises immediately without retrying."""
+        inner = MagicMock()
+        inner.send_request = AsyncMock(side_effect=ValueError("bad input"))
+        svc = RetryLlmService(inner, max_retries=3)
+        with pytest.raises(ValueError):
+            await svc.send_request(_make_request())
+        assert inner.send_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_http_429_status_error(self):
+        """HTTP 429 rate-limit responses are retryable."""
+        resp_mock = MagicMock()
+        resp_mock.status_code = 429
+        rate_limit_exc = Exception("rate limit")
+        rate_limit_exc.response = resp_mock  # type: ignore[attr-defined]
+
+        ok_resp = _make_response("OK after rate limit")
+        inner = MagicMock()
+        inner.send_request = AsyncMock(side_effect=[rate_limit_exc, ok_resp])
+        svc = RetryLlmService(inner, max_retries=3, base_delay=0, jitter=False)
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await svc.send_request(_make_request())
+        assert result.content == "OK after rate limit"
+        assert inner.send_request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_success_no_retry(self):
+        """Successful stream passes chunks through unchanged."""
+
+        async def _gen():
+            yield LlmStreamChunk(content="Hello")
+            yield LlmStreamChunk(content=" world")
+
+        inner = MagicMock()
+        inner.stream_request = MagicMock(return_value=_gen())
+        svc = RetryLlmService(inner)
+        chunks = [c async for c in svc.stream_request(_make_request())]
+        assert [c.content for c in chunks] == ["Hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_stream_does_not_retry_after_chunks_yielded(self):
+        """Once chunks have been yielded, errors must NOT be retried."""
+
+        async def _gen_fail_mid():
+            yield LlmStreamChunk(content="partial")
+            raise RuntimeError("mid-stream failure")
+
+        inner = MagicMock()
+        inner.stream_request = MagicMock(return_value=_gen_fail_mid())
+        svc = RetryLlmService(inner, max_retries=3)
+
+        with pytest.raises(RuntimeError, match="mid-stream failure"):
+            async for _ in svc.stream_request(_make_request()):
+                pass
+        # Only one stream attempt — no retry after chunks started flowing
+        assert inner.stream_request.call_count == 1
+
+    def test_is_retryable_returns_false_for_value_error(self):
+        assert _is_retryable(ValueError("nope")) is False
+
+    def test_is_retryable_returns_true_for_http_500(self):
+        exc = Exception("server error")
+        resp = MagicMock()
+        resp.status_code = 500
+        exc.response = resp  # type: ignore[attr-defined]
+        assert _is_retryable(exc) is True
+
+    @pytest.mark.asyncio
+    async def test_validate_tools_delegates_to_inner(self):
+        inner = MagicMock()
+        inner.validate_tools = AsyncMock(return_value=["unsupported"])
+        svc = RetryLlmService(inner)
+        result = await svc.validate_tools(["tool1"])
+        assert result == ["unsupported"]
+
+
+# ---------------------------------------------------------------------------
+# CachingLlmService
+# ---------------------------------------------------------------------------
+
+
+class TestCachingLlmService:
+    """Tests for CachingLlmService."""
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_then_hit(self):
+        """Second identical request returns cached response (1 upstream call)."""
+        resp = _make_response("cached answer")
+        inner = _make_inner(resp)
+        svc = CachingLlmService(inner, max_size=10)
+
+        req = _make_request("What is 2+2?")
+        r1 = await svc.send_request(req)
+        r2 = await svc.send_request(req)
+
+        assert r1.content == r2.content == "cached answer"
+        assert inner.send_request.call_count == 1
+        assert svc.stats == {"hits": 1, "misses": 1, "size": 1}
+
+    @pytest.mark.asyncio
+    async def test_different_requests_are_separate_cache_entries(self):
+        """Two requests with different content get separate cache entries."""
+        inner = MagicMock()
+        inner.send_request = AsyncMock(
+            side_effect=[_make_response("A"), _make_response("B")]
+        )
+        svc = CachingLlmService(inner)
+        r1 = await svc.send_request(_make_request("Q1"))
+        r2 = await svc.send_request(_make_request("Q2"))
+        assert r1.content == "A"
+        assert r2.content == "B"
+        assert svc.stats["size"] == 2
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response_not_cached(self):
+        """Responses with tool_calls must never be cached."""
+        from vanna.core.tool import ToolCall
+
+        tc = ToolCall(id="tc1", name="run_sql", arguments={"query": "SELECT 1"})
+        resp = _make_response(tool_calls=[tc])
+        inner = _make_inner(resp)
+        svc = CachingLlmService(inner)
+
+        req = _make_request("run it")
+        await svc.send_request(req)
+        await svc.send_request(req)  # second call must hit inner again
+
+        assert inner.send_request.call_count == 2
+        assert svc.stats["size"] == 0
+
+    @pytest.mark.asyncio
+    async def test_eviction_when_cache_full(self):
+        """Oldest entry is evicted when max_size is reached."""
+        inner = MagicMock()
+        inner.send_request = AsyncMock(
+            side_effect=[_make_response(str(i)) for i in range(4)]
+        )
+        svc = CachingLlmService(inner, max_size=2)
+
+        await svc.send_request(_make_request("Q1"))
+        await svc.send_request(_make_request("Q2"))
+        assert svc.stats["size"] == 2
+
+        # Q3 causes eviction of Q1
+        await svc.send_request(_make_request("Q3"))
+        assert svc.stats["size"] == 2
+
+    @pytest.mark.asyncio
+    async def test_invalidate_clears_cache(self):
+        """invalidate() removes all cached entries."""
+        resp = _make_response("hi")
+        inner = _make_inner(resp)
+        svc = CachingLlmService(inner)
+
+        await svc.send_request(_make_request("hello"))
+        assert svc.stats["size"] == 1
+
+        svc.invalidate()
+        assert svc.stats["size"] == 0
+
+        # Next call should miss again
+        await svc.send_request(_make_request("hello"))
+        assert inner.send_request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_always_passes_through(self):
+        """Streaming responses are never cached — always delegated to inner."""
+
+        async def _gen():
+            yield LlmStreamChunk(content="stream chunk")
+
+        inner = MagicMock()
+        inner.stream_request = MagicMock(return_value=_gen())
+        svc = CachingLlmService(inner)
+        chunks = [c async for c in svc.stream_request(_make_request())]
+        assert chunks[0].content == "stream chunk"
+
+    @pytest.mark.asyncio
+    async def test_validate_tools_delegates(self):
+        inner = MagicMock()
+        inner.validate_tools = AsyncMock(return_value=[])
+        svc = CachingLlmService(inner)
+        assert await svc.validate_tools([]) == []
+
+    def test_cache_key_excludes_user_and_metadata(self):
+        """Two requests differing only in user/metadata share the same key."""
+        from vanna.core.user import User
+
+        u1 = User(id="alice", username="a", email="a@x.com", group_memberships=[])
+        u2 = User(id="bob", username="b", email="b@x.com", group_memberships=[])
+
+        req1 = LlmRequest(
+            messages=[LlmMessage(role="user", content="same")],
+            user=u1,
+            metadata={"session": "s1"},
+        )
+        req2 = LlmRequest(
+            messages=[LlmMessage(role="user", content="same")],
+            user=u2,
+            metadata={"session": "s2"},
+        )
+        assert _cache_key(req1) == _cache_key(req2)
+
+    def test_cache_key_differs_for_different_content(self):
+        req1 = _make_request("Hello")
+        req2 = _make_request("Goodbye")
+        assert _cache_key(req1) != _cache_key(req2)
+
+    def test_stats_initial_values(self):
+        inner = MagicMock()
+        svc = CachingLlmService(inner)
+        assert svc.stats == {"hits": 0, "misses": 0, "size": 0}
+
+
+# ---------------------------------------------------------------------------
+# LoggingObservabilityProvider
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingObservabilityProvider:
+    """Tests for LoggingObservabilityProvider."""
+
+    @pytest.mark.asyncio
+    async def test_create_span_returns_span_with_correct_name(self):
+        obs = LoggingObservabilityProvider()
+        span = await obs.create_span("test_operation", {"key": "value"})
+        assert span.name == "test_operation"
+        assert span.attributes == {"key": "value"}
+        assert span.end_time is None  # not yet ended
+
+    @pytest.mark.asyncio
+    async def test_end_span_sets_end_time(self):
+        obs = LoggingObservabilityProvider()
+        span = await obs.create_span("op")
+        await obs.end_span(span)
+        assert span.end_time is not None
+        assert span.duration_ms() is not None
+        assert span.duration_ms() >= 0
+
+    @pytest.mark.asyncio
+    async def test_create_span_logs_at_configured_level(self, caplog):
+        obs = LoggingObservabilityProvider(span_log_level=logging.INFO)
+        with caplog.at_level(logging.INFO, logger="vanna.integrations.local.logging_observability"):
+            span = await obs.create_span("my_span")
+        assert any("SPAN START" in r.message and "my_span" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_end_span_logs_duration(self, caplog):
+        obs = LoggingObservabilityProvider(span_log_level=logging.INFO)
+        with caplog.at_level(logging.INFO, logger="vanna.integrations.local.logging_observability"):
+            span = await obs.create_span("timed_op")
+            caplog.clear()
+            await obs.end_span(span)
+        end_records = [r for r in caplog.records if "SPAN END" in r.message]
+        assert len(end_records) == 1
+        assert "timed_op" in end_records[0].message
+        assert "ms" in end_records[0].message
+
+    @pytest.mark.asyncio
+    async def test_record_metric_logs_name_and_value(self, caplog):
+        obs = LoggingObservabilityProvider(metric_log_level=logging.INFO)
+        with caplog.at_level(logging.INFO, logger="vanna.integrations.local.logging_observability"):
+            await obs.record_metric("agent.tokens", 512.0, unit="tokens", tags={"model": "gpt-4"})
+        metric_records = [r for r in caplog.records if "METRIC" in r.message]
+        assert len(metric_records) == 1
+        assert "agent.tokens" in metric_records[0].message
+        assert "512.0tokens" in metric_records[0].message
+        assert "gpt-4" in metric_records[0].message
+
+    @pytest.mark.asyncio
+    async def test_record_metric_no_tags(self, caplog):
+        obs = LoggingObservabilityProvider(metric_log_level=logging.INFO)
+        with caplog.at_level(logging.INFO, logger="vanna.integrations.local.logging_observability"):
+            await obs.record_metric("requests.total", 1.0)
+        assert any("requests.total" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_create_span_no_attributes(self):
+        obs = LoggingObservabilityProvider()
+        span = await obs.create_span("bare_span")
+        assert span.attributes == {}
+
+    @pytest.mark.asyncio
+    async def test_span_id_in_log(self, caplog):
+        obs = LoggingObservabilityProvider(span_log_level=logging.INFO)
+        with caplog.at_level(logging.INFO, logger="vanna.integrations.local.logging_observability"):
+            span = await obs.create_span("id_check")
+        # First 8 chars of the UUID should appear
+        assert any(span.id[:8] in r.message for r in caplog.records)

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -1,0 +1,341 @@
+"""
+Unit tests for OpenAIResponsesService (integrations/openai/responses.py).
+
+All tests mock the openai client so no real API key is required.
+Integration tests that hit the real API are marked @pytest.mark.openai
+and only run when OPENAI_API_KEY is set.
+"""
+
+import pytest
+import openai
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import AsyncIterator
+
+from vanna.core.llm import LlmRequest, LlmMessage, LlmResponse
+from vanna.core.tool import ToolCall, ToolSchema
+from vanna.core.user import User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_service(model: str = "gpt-test"):
+    """Return an OpenAIResponsesService with a mocked AsyncOpenAI client."""
+    mock_client = MagicMock()
+    with patch.object(openai, "AsyncOpenAI", return_value=mock_client):
+        from vanna.integrations.openai.responses import OpenAIResponsesService
+
+        svc = OpenAIResponsesService(api_key="test-key", model=model)
+    # keep a reference so tests can set up return values
+    svc._mock_client = mock_client
+    return svc
+
+
+def make_user() -> User:
+    return User(
+        id="u1",
+        username="tester",
+        email="tester@example.com",
+        group_memberships=["user"],
+    )
+
+
+def make_request(content: str = "Hello", tools=None) -> LlmRequest:
+    return LlmRequest(
+        messages=[LlmMessage(role="user", content=content)],
+        user=make_user(),
+        tools=tools,
+        metadata={},
+    )
+
+
+class _FakeStream:
+    """Minimal async context manager that behaves like the openai stream object."""
+
+    def __init__(self, events, final_resp):
+        self._events = events
+        self._final = final_resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    def __aiter__(self):
+        return self._aiter()
+
+    async def _aiter(self):
+        for e in self._events:
+            yield e
+
+    async def get_final_response(self):
+        return self._final
+
+
+def _fake_resp(
+    output_text=None,
+    output=None,
+    usage=None,
+    status="completed",
+    resp_id="resp_1",
+):
+    """Build a MagicMock that looks like an openai Responses API response."""
+    resp = MagicMock()
+    resp.output_text = output_text
+    resp.output = output or []
+    resp.usage = usage
+    resp.status = status
+    resp.id = resp_id
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _serialize_tool
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_tool_from_tool_schema():
+    """_serialize_tool must convert ToolSchema → OpenAI function dict."""
+    svc = make_service()
+    schema = ToolSchema(
+        name="run_sql",
+        description="Run a SQL query",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    result = svc._serialize_tool(schema)
+
+    assert result["type"] == "function"
+    assert result["name"] == "run_sql"
+    assert result["description"] == "Run a SQL query"
+    assert result["parameters"] == schema.parameters
+    assert result["strict"] is False
+
+
+def test_serialize_tool_from_dict_with_name_description_parameters():
+    """_serialize_tool must handle plain dict with name/description/parameters."""
+    svc = make_service()
+    tool_dict = {
+        "name": "my_tool",
+        "description": "Does something",
+        "parameters": {"type": "object"},
+    }
+    result = svc._serialize_tool(tool_dict)
+
+    assert result["type"] == "function"
+    assert result["name"] == "my_tool"
+    assert result["strict"] is False
+
+
+def test_serialize_tool_from_dict_with_existing_type():
+    """_serialize_tool must pass through dicts that already have 'type' key."""
+    svc = make_service()
+    tool_dict = {"type": "custom_tool", "name": "foo"}
+    result = svc._serialize_tool(tool_dict)
+    assert result == tool_dict
+
+
+def test_serialize_tool_raises_for_unknown_type():
+    """_serialize_tool must raise TypeError for unsupported inputs."""
+    svc = make_service()
+    with pytest.raises(TypeError, match="Unsupported tool schema type"):
+        svc._serialize_tool(42)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _payload
+# ---------------------------------------------------------------------------
+
+
+def test_payload_basic():
+    """_payload must include model and input messages."""
+    svc = make_service(model="gpt-test")
+    req = make_request("What is 2+2?")
+    payload = svc._payload(req)
+
+    assert payload["model"] == "gpt-test"
+    assert len(payload["input"]) == 1
+    assert payload["input"][0]["role"] == "user"
+    assert payload["input"][0]["content"] == "What is 2+2?"
+    assert "instructions" not in payload
+    assert "tools" not in payload
+
+
+def test_payload_with_system_prompt():
+    """_payload must include instructions when system_prompt is set."""
+    svc = make_service()
+    req = make_request()
+    req.system_prompt = "You are a helpful assistant."
+    payload = svc._payload(req)
+    assert payload["instructions"] == "You are a helpful assistant."
+
+
+def test_payload_with_max_tokens():
+    """_payload must include max_output_tokens when max_tokens is set."""
+    svc = make_service()
+    req = make_request()
+    req.max_tokens = 512
+    payload = svc._payload(req)
+    assert payload["max_output_tokens"] == 512
+
+
+def test_payload_with_tools():
+    """_payload must serialize tools when present."""
+    svc = make_service()
+    schema = ToolSchema(
+        name="run_sql",
+        description="Run SQL",
+        parameters={"type": "object"},
+    )
+    req = make_request(tools=[schema])
+    payload = svc._payload(req)
+    assert "tools" in payload
+    assert len(payload["tools"]) == 1
+    assert payload["tools"][0]["name"] == "run_sql"
+
+
+# ---------------------------------------------------------------------------
+# _extract
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_response():
+    """_extract must return output_text as content."""
+    svc = make_service()
+    resp = _fake_resp(output_text="Hello!")
+    text, tools, status, usage = svc._extract(resp)
+    assert text == "Hello!"
+    assert tools is None
+    assert status == "completed"
+    assert usage is None
+
+
+def test_extract_with_usage():
+    """_extract must parse usage tokens."""
+    svc = make_service()
+    mock_usage = MagicMock()
+    mock_usage.input_tokens = 10
+    mock_usage.output_tokens = 20
+    mock_usage.total_tokens = None  # force computation
+    resp = _fake_resp(output_text="Hi", usage=mock_usage)
+
+    _text, _tools, _status, usage = svc._extract(resp)
+    assert usage is not None
+    assert usage["input_tokens"] == 10
+    assert usage["output_tokens"] == 20
+    assert usage["total_tokens"] == 30  # computed as input + output
+
+
+def test_extract_no_tool_calls_in_plain_output():
+    """_extract must return no tool_calls when output has no tool_call items."""
+    svc = make_service()
+    # output item has content but no tool_call type
+    item = MagicMock()
+    item.type = "text"
+    output_item = MagicMock()
+    output_item.content = [item]
+    resp = _fake_resp(output=[output_item])
+
+    _text, tools, _status, _usage = svc._extract(resp)
+    assert tools is None
+
+
+# ---------------------------------------------------------------------------
+# validate_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_tools_always_empty():
+    """validate_tools must return an empty list (accepts any schema)."""
+    svc = make_service()
+    schema = ToolSchema(name="t", description="d", parameters={})
+    result = await svc.validate_tools([schema])
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# send_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_request_text_only():
+    """send_request must return LlmResponse with content and no tool_calls."""
+    svc = make_service()
+    resp = _fake_resp(output_text="42", status="completed", resp_id="r1")
+    svc._mock_client.responses.create = AsyncMock(return_value=resp)
+
+    result = await svc.send_request(make_request("What is 6x7?"))
+
+    assert isinstance(result, LlmResponse)
+    assert result.content == "42"
+    assert result.tool_calls is None
+    assert result.finish_reason == "completed"
+    assert result.metadata.get("request_id") == "r1"
+
+
+@pytest.mark.asyncio
+async def test_send_request_passes_payload_to_client():
+    """send_request must call client.responses.create with the built payload."""
+    svc = make_service(model="gpt-foo")
+    resp = _fake_resp(output_text="ok")
+    svc._mock_client.responses.create = AsyncMock(return_value=resp)
+
+    await svc.send_request(make_request("test"))
+
+    call_kwargs = svc._mock_client.responses.create.call_args[1]
+    assert call_kwargs["model"] == "gpt-foo"
+    assert call_kwargs["input"][0]["content"] == "test"
+
+
+# ---------------------------------------------------------------------------
+# stream_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_request_yields_text_chunks():
+    """stream_request must yield LlmStreamChunk with content for text deltas."""
+    svc = make_service()
+
+    mock_event = MagicMock()
+    mock_event.type = "response.output_text.delta"
+    mock_event.delta = "Hello"
+
+    final_resp = _fake_resp(output_text="Hello", status="completed")
+    svc._mock_client.responses.stream.return_value = _FakeStream(
+        events=[mock_event], final_resp=final_resp
+    )
+
+    chunks = []
+    async for chunk in svc.stream_request(make_request("Hi")):
+        chunks.append(chunk)
+
+    text_chunks = [c for c in chunks if c.content]
+    assert any(c.content == "Hello" for c in text_chunks)
+
+
+@pytest.mark.asyncio
+async def test_stream_request_ignores_non_delta_events():
+    """stream_request must silently skip events that aren't text deltas."""
+    svc = make_service()
+
+    irrelevant_event = MagicMock()
+    irrelevant_event.type = "response.created"
+    irrelevant_event.delta = None
+
+    final_resp = _fake_resp(output_text=None, status="completed")
+    svc._mock_client.responses.stream.return_value = _FakeStream(
+        events=[irrelevant_event], final_resp=final_resp
+    )
+
+    chunks = []
+    async for chunk in svc.stream_request(make_request("Hi")):
+        chunks.append(chunk)
+
+    # No text content expected — only the final status/tool chunk
+    text_chunks = [c for c in chunks if c.content is not None]
+    assert len(text_chunks) == 0

--- a/tests/test_regression_fixes.py
+++ b/tests/test_regression_fixes.py
@@ -1,0 +1,246 @@
+"""
+Regression tests for fixes applied in PR #1 (2026-02-21).
+
+Covers:
+  #1069 — FastAPI duplicate keyword arg (title/description/version)
+  #1078 — Legacy SQL injection guard (is_sql_valid before run_sql)
+  #190  — Graceful handling when LLM returns plain text instead of SQL
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+class MockVanna:
+    """Minimal concrete VannaBase subclass for unit tests.
+
+    Uses MockLLM + MockVectorDB so all abstract methods are satisfied
+    without requiring real databases or LLM credentials.
+    """
+
+    pass
+
+
+@pytest.fixture
+def vanna_instance():
+    """Return a fully-constructed mock VannaBase instance."""
+    from vanna.legacy.mock.embedding import MockEmbedding
+    from vanna.legacy.mock.llm import MockLLM
+    from vanna.legacy.mock.vectordb import MockVectorDB
+
+    class MinimalVanna(MockVectorDB, MockLLM, MockEmbedding):
+        def __init__(self, config=None):
+            MockVectorDB.__init__(self, config=config)
+            MockLLM.__init__(self, config=config)
+            MockEmbedding.__init__(self, config=config)
+
+    return MinimalVanna()
+
+
+# ---------------------------------------------------------------------------
+# #1069 — FastAPI duplicate keyword arg
+# ---------------------------------------------------------------------------
+
+
+def test_fastapi_create_app_with_custom_title():
+    """#1069 — create_app() must not raise TypeError when title is in config."""
+    from unittest.mock import MagicMock
+
+    from vanna.servers.fastapi.app import VannaFastAPIServer
+
+    agent = MagicMock()
+    server = VannaFastAPIServer(
+        agent=agent,
+        config={"fastapi": {"title": "My API"}},
+    )
+    app = server.create_app()
+    assert app.title == "My API"
+
+
+def test_fastapi_create_app_with_all_config_keys():
+    """#1069 — create_app() must not raise when title, description, and version
+    are all present in the fastapi config dict."""
+    from vanna.servers.fastapi.app import VannaFastAPIServer
+
+    agent = MagicMock()
+    server = VannaFastAPIServer(
+        agent=agent,
+        config={
+            "fastapi": {
+                "title": "Custom Title",
+                "description": "Custom Description",
+                "version": "3.1.4",
+            }
+        },
+    )
+    # Before the fix this raised:
+    # TypeError: FastAPI.__init__() got multiple values for keyword argument 'title'
+    app = server.create_app()
+    assert app.title == "Custom Title"
+    assert app.description == "Custom Description"
+    assert app.version == "3.1.4"
+
+
+def test_fastapi_create_app_default_config():
+    """#1069 — create_app() works with empty config (baseline)."""
+    from vanna.servers.fastapi.app import VannaFastAPIServer
+
+    agent = MagicMock()
+    server = VannaFastAPIServer(agent=agent)
+    app = server.create_app()
+    assert app.title == "Vanna Agents API"
+    assert app.version == "0.1.0"
+
+
+# ---------------------------------------------------------------------------
+# #1078 — is_sql_valid() gates
+# ---------------------------------------------------------------------------
+
+
+def test_is_sql_valid_accepts_select(vanna_instance):
+    """#1078 — is_sql_valid must return True for a SELECT statement."""
+    assert vanna_instance.is_sql_valid("SELECT * FROM users") is True
+
+
+def test_is_sql_valid_accepts_select_with_leading_whitespace(vanna_instance):
+    """#1078 — is_sql_valid handles leading whitespace before SELECT."""
+    assert vanna_instance.is_sql_valid("  SELECT id FROM orders WHERE id = 1") is True
+
+
+def test_is_sql_valid_rejects_drop(vanna_instance):
+    """#1078 — is_sql_valid must return False for DROP TABLE."""
+    assert vanna_instance.is_sql_valid("DROP TABLE users") is False
+
+
+def test_is_sql_valid_rejects_delete(vanna_instance):
+    """#1078 — is_sql_valid must return False for DELETE."""
+    assert vanna_instance.is_sql_valid("DELETE FROM users WHERE id = 1") is False
+
+
+def test_is_sql_valid_rejects_insert(vanna_instance):
+    """#1078 — is_sql_valid must return False for INSERT."""
+    assert vanna_instance.is_sql_valid("INSERT INTO users VALUES (1, 'alice')") is False
+
+
+def test_is_sql_valid_rejects_plain_text(vanna_instance):
+    """#1078/#190 — is_sql_valid must return False for plain-text LLM responses."""
+    assert (
+        vanna_instance.is_sql_valid(
+            "I'm sorry, I cannot generate SQL for this request."
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# #190 — ask() graceful handling of plain-text LLM responses
+# ---------------------------------------------------------------------------
+
+
+def test_ask_returns_text_when_llm_returns_plain_text(vanna_instance):
+    """#190 — When the LLM returns plain text instead of SQL, ask() must
+    return (text, None, None) without crashing."""
+    plain_text = "I cannot generate SQL for this philosophical question."
+
+    with patch.object(vanna_instance, "generate_sql", return_value=plain_text):
+        result = vanna_instance.ask(
+            "What is the meaning of life?", print_results=False
+        )
+
+    sql, df, fig = result
+    assert sql == plain_text
+    assert df is None
+    assert fig is None
+
+
+def test_ask_returns_early_for_drop_table(vanna_instance):
+    """#1078 — ask() must return (sql, None, None) without executing a
+    DROP TABLE statement returned by the LLM."""
+    dangerous_sql = "DROP TABLE users"
+
+    with patch.object(vanna_instance, "generate_sql", return_value=dangerous_sql):
+        # run_sql must never be called for invalid SQL
+        with patch.object(vanna_instance, "run_sql") as mock_run_sql:
+            result = vanna_instance.ask("Delete all users", print_results=False)
+            mock_run_sql.assert_not_called()
+
+    sql, df, fig = result
+    assert sql == dangerous_sql
+    assert df is None
+    assert fig is None
+
+
+def test_ask_returns_early_for_delete_statement(vanna_instance):
+    """#1078 — ask() must stop before run_sql for DELETE statements."""
+    delete_sql = "DELETE FROM orders WHERE total < 0"
+
+    with patch.object(vanna_instance, "generate_sql", return_value=delete_sql):
+        with patch.object(vanna_instance, "run_sql") as mock_run_sql:
+            result = vanna_instance.ask("Remove bad orders", print_results=False)
+            mock_run_sql.assert_not_called()
+
+    sql, df, fig = result
+    assert sql == delete_sql
+    assert df is None
+    assert fig is None
+
+
+def test_ask_proceeds_for_valid_select(vanna_instance):
+    """#1078/#190 — ask() must call run_sql for a valid SELECT statement."""
+    import pandas as pd
+
+    # run_sql_is_set is normally set by connect_to_*() helpers; set it here
+    # so ask() doesn't bail out at the "not connected" check.
+    vanna_instance.run_sql_is_set = True
+
+    valid_sql = "SELECT * FROM users LIMIT 10"
+    mock_df = pd.DataFrame({"id": [1, 2], "name": ["alice", "bob"]})
+
+    with patch.object(vanna_instance, "generate_sql", return_value=valid_sql):
+        with patch.object(vanna_instance, "run_sql", return_value=mock_df) as mock_run:
+            result = vanna_instance.ask(
+                "Show all users", print_results=False, visualize=False
+            )
+            mock_run.assert_called_once_with(valid_sql)
+
+    sql, df, fig = result
+    assert sql == valid_sql
+    assert df is not None
+    assert list(df.columns) == ["id", "name"]
+
+
+# ---------------------------------------------------------------------------
+# Flask /run_sql is_sql_valid guard (#1078)
+# ---------------------------------------------------------------------------
+
+
+def test_flask_run_sql_guard_rejects_non_select(vanna_instance):
+    """#1078 — The Flask /api/v0/run_sql endpoint must return an error JSON
+    (not execute) when the cached SQL fails is_sql_valid()."""
+    pytest.importorskip("flask", reason="flask not installed")
+    from vanna.legacy.flask import VannaFlaskApp
+
+    app_wrapper = VannaFlaskApp(vanna_instance)
+    client = app_wrapper.flask_app.test_client()
+
+    # Inject a dangerous SQL string into the cache and attempt to run it
+    cache_id = app_wrapper.cache.generate_id(question="drop test")
+    app_wrapper.cache.set(id=cache_id, field="question", value="drop test")
+    app_wrapper.cache.set(
+        id=cache_id, field="sql", value="DROP TABLE users"
+    )
+
+    resp = client.get(f"/api/v0/run_sql?id={cache_id}")
+    data = resp.get_json()
+
+    assert data is not None
+    assert data.get("type") == "error"
+    # run_sql must never have been called
+    with patch.object(vanna_instance, "run_sql") as mock_run:
+        mock_run.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     py311-agent-memory-sanity
     py311-anthropic
     py311-openai
+    py311-openai-responses
+    py311-gemini
     py311-legacy
     py311-chromadb
     py311-qdrant
@@ -59,15 +61,23 @@ commands =
     python -c "from vanna.integrations.openai import OpenAILlmService; print('✓ OpenAI import successful')"
     pytest tests/ -v -m openai
 
-; [testenv:py311-gemini]
-; description = Test with Google Gemini
-; extras = gemini
-; passenv =
-;     GOOGLE_API_KEY
-;     GEMINI_API_KEY
-; commands =
-;     python -c "from vanna.integrations.google import GeminiLlmService; print('✓ Gemini import successful')"
-;     pytest tests/ -v -m gemini
+[testenv:py311-openai-responses]
+description = Test OpenAI Responses API integration
+extras = openai
+passenv = OPENAI_API_KEY
+commands =
+    python -c "from vanna.integrations.openai.responses import OpenAIResponsesService; print('✓ OpenAIResponsesService import successful')"
+    pytest tests/test_openai_responses.py -v
+
+[testenv:py311-gemini]
+description = Test with Google Gemini
+extras = gemini
+passenv =
+    GOOGLE_API_KEY
+    GEMINI_API_KEY
+commands =
+    python -c "from vanna.integrations.google import GeminiLlmService; print('✓ Gemini import successful')"
+    pytest tests/ -v -m gemini
 
 ; [testenv:py311-ollama]
 ; description = Test with Ollama


### PR DESCRIPTION
## Summary

This PR addresses several bugs reported in the issue tracker, adds three new utility integrations, improves the evaluation runner, and ships 58 new offline tests.

---

## Bug Fixes

### #1069 — FastAPI `TypeError: multiple values for keyword argument`
- **`servers/fastapi/app.py`**: copy the `app_config` dict, then `.pop()` `title`/`description`/`version` before spreading with `**app_config` so user-provided keys never collide with positional arguments.

### #1073 — Gemini 3 `thought_signature` support
- **`core/tool/models.py`**: added `thought_signature: Optional[bytes] = None` to `ToolCall`.
- **`integrations/google/gemini.py`**: `_parse_response()` captures `part.thought_signature`; `stream_request()` scans **all** chunks (not just the last) for tool calls; `_build_payload()` pre-builds a `thought_sig_by_call_id` lookup and passes the signature through both function-call and function-response `Part` kwargs.

### #1078 — SQL injection via prompt injection (legacy API)
- **`legacy/base/base.py`**: `ask()` calls `is_sql_valid()` before displaying or executing SQL; non-SELECT statements are blocked and the raw LLM text is printed instead.
- **`legacy/flask/__init__.py`**: `/api/v0/run_sql` endpoint validates SQL before running, returns a JSON error for disallowed statements.

### #190 — Graceful handling when LLM returns no SQL
- Covered by the same `is_sql_valid()` guard in `ask()` — plain-text LLM responses fail validation cleanly and are printed as informational messages rather than crashing.

### Pinecone embedding — `_create_embedding()` was producing MD5 hashes
- **`integrations/pinecone/agent_memory.py`**: replaced the MD5 placeholder with real `sentence-transformers` encoding (`all-MiniLM-L6-v2` by default, configurable via `embedding_model` parameter). Similarity search now works correctly.

---

## New Features

### Thinking indicator
- **`core/agent/agent.py`**: the TODO stub now yields a real `StatusIndicatorComponent(status="loading", message="Thinking...", pulse=True)` before the first LLM call when `config.include_thinking_indicators` is enabled.

### Evaluation runner — trajectory recording
- **`core/evaluation/runner.py`**: added `_RecordingLlmMiddleware` (one instance per test case, no shared state across concurrent runs). `_execute_agent()` now creates a per-run agent copy with a fresh `MemoryConversationStore` and the recorder appended to `llm_middlewares`, so `AgentResult.tool_calls`, `llm_requests`, and `total_tokens` are fully populated instead of empty.

### `RetryLlmService` (`integrations/local/retry_llm.py`)
- `LlmService` decorator with exponential-backoff retry for transient failures (`httpx` timeouts, connection errors, HTTP 429/500/502/503/504).
- `stream_request` only retries if zero chunks have been yielded — prevents duplicate content in the caller's accumulator.
- Parameters: `max_retries=3`, `base_delay=1.0s`, `max_delay=30.0s`, `jitter=True`.

### `CachingLlmService` (`integrations/local/caching_llm.py`)
- `LlmService` decorator with a SHA-256 keyed, insertion-order LRU in-memory cache.
- Cache key covers `system_prompt`, `messages`, `tools`, `temperature`, `max_tokens` — deliberately excludes `user` and `metadata` so different users asking the same question share the cached answer.
- Never caches tool-call responses (provider-specific state) or streaming responses.
- Exposes `stats` (hits/misses/size) and `invalidate()`.

### `LoggingObservabilityProvider` (`integrations/local/logging_observability.py`)
- `ObservabilityProvider` implementation that writes span lifecycle events (start, end with duration) and metric measurements to Python's standard `logging` module.
- Zero external dependencies. Configurable log levels for spans and metrics separately.

---

## Tests Added

| File | Coverage |
|---|---|
| `tests/test_regression_fixes.py` | 14 tests — FastAPI keyword-arg fix, SQL injection guard, no-SQL handling |
| `tests/test_openai_responses.py` | 16 tests — `OpenAIResponsesService`: tool serialization, payload building, response extraction, streaming |
| `tests/test_local_wrappers.py` | 28 tests — `RetryLlmService`, `CachingLlmService`, `LoggingObservabilityProvider` |

**58 new tests total, all passing offline (no real API keys required).**

---

## `tox.ini`
- Added `py311-openai-responses` environment for the new `OpenAIResponsesService` test suite.
- Re-enabled the `py311-gemini` environment (was previously commented out).

---

## Files Changed

| Path | Change |
|---|---|
| `src/vanna/servers/fastapi/app.py` | Fix keyword-arg collision (#1069) |
| `src/vanna/core/tool/models.py` | Add `thought_signature` field (#1073) |
| `src/vanna/integrations/google/gemini.py` | Full `thought_signature` plumbing (#1073) |
| `src/vanna/legacy/base/base.py` | SQL validation in `ask()` (#1078, #190) |
| `src/vanna/legacy/flask/__init__.py` | SQL validation in `/api/v0/run_sql` (#1078) |
| `src/vanna/integrations/pinecone/agent_memory.py` | Real sentence-transformer embeddings |
| `src/vanna/core/agent/agent.py` | Thinking indicator |
| `src/vanna/core/evaluation/runner.py` | Trajectory recording middleware |
| `src/vanna/integrations/local/retry_llm.py` | **New** — `RetryLlmService` |
| `src/vanna/integrations/local/caching_llm.py` | **New** — `CachingLlmService` |
| `src/vanna/integrations/local/logging_observability.py` | **New** — `LoggingObservabilityProvider` |
| `src/vanna/integrations/local/__init__.py` | Export new integrations |
| `tests/test_regression_fixes.py` | **New** — 14 regression tests |
| `tests/test_openai_responses.py` | **New** — 16 OpenAI Responses tests |
| `tests/test_local_wrappers.py` | **New** — 28 wrapper tests |
| `tox.ini` | New test env + re-enable Gemini env |
